### PR TITLE
ci: separate noir installation github action

### DIFF
--- a/.github/actions/install-nargo/action.yml
+++ b/.github/actions/install-nargo/action.yml
@@ -4,6 +4,8 @@ description: "Installs the noir-lang toolchain"
 runs:
   using: "composite"
   steps:
-    uses: noir-lang/noirup@v0.1.4
-    with:
-      toolchain: stable
+    - shell: bash
+      run: |
+        curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
+        source ~/.bashrc
+        ~/.nargo/bin/noirup --version

--- a/.github/actions/install-nargo/action.yml
+++ b/.github/actions/install-nargo/action.yml
@@ -1,0 +1,9 @@
+name: "Install Nargo"
+description: "Installs the noir-lang toolchain"
+
+runs:
+  using: "composite"
+  steps:
+    uses: noir-lang/noirup@v0.1.4
+    with:
+      toolchain: stable

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -50,10 +50,13 @@ jobs:
       - name: Install nightly-2024-08-01 with rust-src for Powdr
         run: rustup toolchain install nightly-2024-08-01 --component rust-src
       
-      - name: Build full workspace (release)
+      - name: Install Nargo
+        uses: ./.github/actions/install-nargo
+      
+      - name: Build full workspace
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }} # for ACIR (required by protoc-prebuilt)
-        run: cargo build --release --workspace
+        run: cargo build --workspace
       
       - name: Format
         run: cargo fmt --all -- --check

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -39,6 +39,22 @@ jobs:
           default: true
           components: rustfmt, clippy
 
+      - name: Install SP1
+        uses: ./.github/actions/install-sp1
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Install Powdr
+        uses: ./.github/actions/install-powdr
+
+      - name: Install nightly-2024-08-01 with rust-src for Powdr
+        run: rustup toolchain install nightly-2024-08-01 --component rust-src
+      
+      - name: Build full workspace (release)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }} # for ACIR (required by protoc-prebuilt)
+        run: cargo build --release --workspace
+      
       - name: Format
         run: cargo fmt --all -- --check
 

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,0 +1,46 @@
+name: Lints
+
+on:
+  pull_request:
+    branches:
+      - "CSP-Q3-2025"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+# ────────────────── 1. Warm‑up build ──────────────────
+jobs:
+  fmt:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache everything
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+            ~/.rustup
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2025-04-05-aarch64-apple-darwin
+          override: true
+          profile: default
+          default: true
+          components: rustfmt, clippy
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets --all-features

--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -50,7 +50,7 @@ jobs:
           override: true
           profile: default
           default: true
-          components: llvm-tools, rustc-dev, rustfmt
+          components: llvm-tools, rustc-dev
 
       - name: Install SP1
         uses: ./.github/actions/install-sp1
@@ -63,16 +63,10 @@ jobs:
       - name: Install nightly-2024-08-01 with rust-src for Powdr
         run: rustup toolchain install nightly-2024-08-01 --component rust-src
 
-      - name: Format
-        run: cargo fmt --all -- --check
-
       - name: Build full workspace (release)
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }} # for ACIR (required by protoc-prebuilt)
         run: cargo build --release --workspace
-
-      - name: Clippy
-        run: cargo clippy --workspace --all-targets --all-features
 
   detect-crates:
     needs: prepare-cache

--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -196,9 +196,7 @@ jobs:
         run: rustup toolchain install nightly-2024-08-01 --component rust-src
 
       - name: Install Nargo
-        uses: noir-lang/noirup@v0.1.4
-        with:
-          toolchain: stable
+        uses: ./.github/actions/install-nargo
 
       - name: Run benches in ${{ matrix.crate }}
         run: |

--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -50,7 +50,7 @@ jobs:
           override: true
           profile: default
           default: true
-          components: llvm-tools, rustc-dev
+          components: llvm-tools, rustc-dev, rustfmt
 
       - name: Install SP1
         uses: ./.github/actions/install-sp1

--- a/.github/workflows/rust_benchmarks_serial.yml
+++ b/.github/workflows/rust_benchmarks_serial.yml
@@ -35,7 +35,7 @@ jobs:
           override: true
           profile: default
           default: true
-          components: llvm-tools, rustc-dev, rustfmt
+          components: llvm-tools, rustc-dev
 
       - name: Install SP1
         uses: ./.github/actions/install-sp1
@@ -48,16 +48,10 @@ jobs:
       - name: Install nightly-2024-08-01 with rust-src for Powdr
         run: rustup toolchain install nightly-2024-08-01 --component rust-src
 
-      - name: Format
-        run: cargo fmt --all -- --check
-
       - name: Build full workspace (release)
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }} # for ACIR (required by protoc-prebuilt)
         run: cargo build --release --workspace
-
-      - name: Clippy
-        run: cargo clippy --workspace --all-targets --all-features
 
   # ────────────────── 2. Rust workspace benchmarks ──────────────────
   bench-workspace:

--- a/.github/workflows/rust_benchmarks_serial.yml
+++ b/.github/workflows/rust_benchmarks_serial.yml
@@ -35,7 +35,7 @@ jobs:
           override: true
           profile: default
           default: true
-          components: llvm-tools, rustc-dev
+          components: llvm-tools, rustc-dev, rustfmt
 
       - name: Install SP1
         uses: ./.github/actions/install-sp1

--- a/.github/workflows/rust_benchmarks_serial.yml
+++ b/.github/workflows/rust_benchmarks_serial.yml
@@ -98,9 +98,7 @@ jobs:
         run: rustup toolchain install nightly-2024-08-01 --component rust-src
 
       - name: Install Nargo
-        uses: noir-lang/noirup@v0.1.4
-        with:
-          toolchain: stable
+        uses: ./.github/actions/install-nargo
 
       - name: Run workspace benchmarks
         run: cargo bench


### PR DESCRIPTION
- Closes #27  
- Partially related to #29 (split the `fmt` and `clippy` to separate workflow)