### PR TITLE
ref: unify inputs across the benchmarks

### DIFF
--- a/.github/actions/install-nargo/action.yml
+++ b/.github/actions/install-nargo/action.yml
@@ -9,3 +9,4 @@ runs:
         curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
         source ~/.bashrc
         ~/.nargo/bin/noirup --version 1.0.0-beta.9
+        echo "$HOME/.nargo/bin" >> $GITHUB_PATH

--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -65,6 +65,8 @@ jobs:
         run: rustup toolchain install nightly-2024-08-01 --component rust-src
 
       - name: Build full workspace (release)
+        env:
+            GITHUB_TOKEN: ${{ secrets.GH_PAT }} # for ACIR (required by protoc-prebuilt)
         run: cargo build --release --workspace
 
   detect-crates:

--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -65,8 +65,6 @@ jobs:
         run: rustup toolchain install nightly-2024-08-01 --component rust-src
 
       - name: Build full workspace (release)
-        env:
-            GITHUB_TOKEN: ${{ secrets.GH_PAT }} # for ACIR (required by protoc-prebuilt)
         run: cargo build --release --workspace
 
   detect-crates:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,14 +68,8 @@ Example:
   "is_zkvm": false,
   "target": "sha256",
   "input_size": 2048,
-  "proof_duration": {
-    "secs": 9,
-    "nanos": 912673217
-  },
-  "verify_duration": {
-    "secs": 3,
-    "nanos": 933078432
-  },
+  "proof_duration": 10644587248,
+  "verify_duration": 4647043282,
   "cycles": 0,
   "proof_size": 475590,
   "preprocessing_size": 329524,

--- a/binius/benches/sha256_bench.rs
+++ b/binius/benches/sha256_bench.rs
@@ -9,93 +9,95 @@ use utils::{
 };
 
 fn sha256_no_lookup(c: &mut Criterion) {
-    // Measure the metrics
-    let input_size = SHA2_INPUTS[0];
-    let metrics = sha256_binius_no_lookup_metrics(input_size);
+    for input_size in SHA2_INPUTS {
+        // Measure the metrics
+        let metrics = sha256_binius_no_lookup_metrics(input_size);
 
-    let json_file = format!("sha256_{input_size}_binius_no_lookup_metrics.json");
-    write_json_metrics(&json_file, &metrics);
+        let json_file = format!("sha256_{input_size}_binius_no_lookup_metrics.json");
+        write_json_metrics(&json_file, &metrics);
 
-    // Run the benchmarks
-    let mut group = c.benchmark_group(format!("sha256_{input_size}_binius_no_lookup"));
-    group.sample_size(10);
-    let allocator = bumpalo::Bump::new();
+        // Run the benchmarks
+        let mut group = c.benchmark_group(format!("sha256_{input_size}_binius_no_lookup"));
+        group.sample_size(10);
+        let allocator = bumpalo::Bump::new();
 
-    group.bench_function(
-        format!("sha256_{input_size}_binius_no_lookup_prove"),
-        |bench| {
-            bench.iter_batched(
-                || sha256_no_lookup_prepare(&allocator),
-                |(constraint_system, args, witness, backend)| {
-                    prove(constraint_system, args, witness, backend);
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
+        group.bench_function(
+            format!("sha256_{input_size}_binius_no_lookup_prove"),
+            |bench| {
+                bench.iter_batched(
+                    || sha256_no_lookup_prepare(&allocator),
+                    |(constraint_system, args, witness, backend)| {
+                        prove(constraint_system, args, witness, backend);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
 
-    group.bench_function(
-        format!("sha256_{input_size}_binius_no_lookup_verify"),
-        |bench| {
-            bench.iter_batched(
-                || {
-                    let (constraint_system, args, witness, backend) =
-                        sha256_no_lookup_prepare(&allocator);
-                    prove(constraint_system, args, witness, backend)
-                },
-                |(constraint_system, args, proof)| {
-                    verify(constraint_system, args, proof);
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
-    group.finish();
+        group.bench_function(
+            format!("sha256_{input_size}_binius_no_lookup_verify"),
+            |bench| {
+                bench.iter_batched(
+                    || {
+                        let (constraint_system, args, witness, backend) =
+                            sha256_no_lookup_prepare(&allocator);
+                        prove(constraint_system, args, witness, backend)
+                    },
+                    |(constraint_system, args, proof)| {
+                        verify(constraint_system, args, proof);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+        group.finish();   
+    }
 }
 
 fn sha256_with_lookup(c: &mut Criterion) {
-    // Measure the metrics
-    let input_size = SHA2_INPUTS[0];
-    let metrics = sha256_binius_with_lookup_metrics(input_size);
+    for input_size in SHA2_INPUTS {
+        // Measure the metrics
+        let metrics = sha256_binius_with_lookup_metrics(input_size);
 
-    let json_file = format!("sha256_{input_size}_binius_with_lookup_metrics.json");
-    write_json_metrics(&json_file, &metrics);
+        let json_file = format!("sha256_{input_size}_binius_with_lookup_metrics.json");
+        write_json_metrics(&json_file, &metrics);
 
-    // Run the benchmarks
-    let mut group = c.benchmark_group(format!("sha256_{input_size}_binius_with_lookup"));
-    group.sample_size(10);
-    let allocator = bumpalo::Bump::new();
+        // Run the benchmarks
+        let mut group = c.benchmark_group(format!("sha256_{input_size}_binius_with_lookup"));
+        group.sample_size(10);
+        let allocator = bumpalo::Bump::new();
 
-    group.bench_function(
-        format!("sha256_{input_size}_binius_with_lookup_prove"),
-        |bench| {
-            bench.iter_batched(
-                || sha256_with_lookup_prepare(&allocator),
-                |(constraint_system, args, witness, backend)| {
-                    prove(constraint_system, args, witness, backend);
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
+        group.bench_function(
+            format!("sha256_{input_size}_binius_with_lookup_prove"),
+            |bench| {
+                bench.iter_batched(
+                    || sha256_with_lookup_prepare(&allocator),
+                    |(constraint_system, args, witness, backend)| {
+                        prove(constraint_system, args, witness, backend);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
 
-    group.bench_function(
-        format!("sha256_{input_size}_binius_with_lookup_verify"),
-        |bench| {
-            bench.iter_batched(
-                || {
-                    let (constraint_system, args, witness, backend) =
-                        sha256_with_lookup_prepare(&allocator);
-                    prove(constraint_system, args, witness, backend)
-                },
-                |(constraint_system, args, proof)| {
-                    verify(constraint_system, args, proof);
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
-    group.finish();
+        group.bench_function(
+            format!("sha256_{input_size}_binius_with_lookup_verify"),
+            |bench| {
+                bench.iter_batched(
+                    || {
+                        let (constraint_system, args, witness, backend) =
+                            sha256_with_lookup_prepare(&allocator);
+                        prove(constraint_system, args, witness, backend)
+                    },
+                    |(constraint_system, args, proof)| {
+                        verify(constraint_system, args, proof);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+        group.finish();   
+    }
 }
 
 criterion_main!(sha256);

--- a/binius/benches/sha256_bench.rs
+++ b/binius/benches/sha256_bench.rs
@@ -50,7 +50,7 @@ fn sha256_no_lookup(c: &mut Criterion) {
                 );
             },
         );
-        group.finish();   
+        group.finish();
     }
 }
 
@@ -96,7 +96,7 @@ fn sha256_with_lookup(c: &mut Criterion) {
                 );
             },
         );
-        group.finish();   
+        group.finish();
     }
 }
 

--- a/binius/benches/sha256_bench.rs
+++ b/binius/benches/sha256_bench.rs
@@ -3,83 +3,98 @@
 use binius::bench::{prove, sha256_no_lookup_prepare, sha256_with_lookup_prepare, verify};
 use binius_utils::SerializeBytes;
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use utils::bench::{Metrics, write_json_metrics};
+use utils::{
+    bench::{Metrics, write_json_metrics},
+    metadata::SHA2_INPUTS,
+};
 
 fn sha256_no_lookup(c: &mut Criterion) {
     // Measure the metrics
-    let input_size = 2048;
+    let input_size = SHA2_INPUTS[0];
     let metrics = sha256_binius_no_lookup_metrics(input_size);
 
-    let json_file = "sha256_2048_binius_no_lookup_metrics.json";
-    write_json_metrics(json_file, &metrics);
+    let json_file = format!("sha256_{input_size}_binius_no_lookup_metrics.json");
+    write_json_metrics(&json_file, &metrics);
 
     // Run the benchmarks
-    let mut group = c.benchmark_group("sha256_2048_binius_no_lookup");
+    let mut group = c.benchmark_group(format!("sha256_{input_size}_binius_no_lookup"));
     group.sample_size(10);
     let allocator = bumpalo::Bump::new();
 
-    group.bench_function("sha256_2048_binius_no_lookup_prove", |bench| {
-        bench.iter_batched(
-            || sha256_no_lookup_prepare(&allocator),
-            |(constraint_system, args, witness, backend)| {
-                prove(constraint_system, args, witness, backend);
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    group.bench_function(
+        format!("sha256_{input_size}_binius_no_lookup_prove"),
+        |bench| {
+            bench.iter_batched(
+                || sha256_no_lookup_prepare(&allocator),
+                |(constraint_system, args, witness, backend)| {
+                    prove(constraint_system, args, witness, backend);
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
 
-    group.bench_function("sha256_2048_binius_no_lookup_verify", |bench| {
-        bench.iter_batched(
-            || {
-                let (constraint_system, args, witness, backend) =
-                    sha256_no_lookup_prepare(&allocator);
-                prove(constraint_system, args, witness, backend)
-            },
-            |(constraint_system, args, proof)| {
-                verify(constraint_system, args, proof);
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    group.bench_function(
+        format!("sha256_{input_size}_binius_no_lookup_verify"),
+        |bench| {
+            bench.iter_batched(
+                || {
+                    let (constraint_system, args, witness, backend) =
+                        sha256_no_lookup_prepare(&allocator);
+                    prove(constraint_system, args, witness, backend)
+                },
+                |(constraint_system, args, proof)| {
+                    verify(constraint_system, args, proof);
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
     group.finish();
 }
 
 fn sha256_with_lookup(c: &mut Criterion) {
     // Measure the metrics
-    let input_size = 2048;
+    let input_size = SHA2_INPUTS[0];
     let metrics = sha256_binius_with_lookup_metrics(input_size);
 
-    let json_file = "sha256_2048_binius_with_lookup_metrics.json";
-    write_json_metrics(json_file, &metrics);
+    let json_file = format!("sha256_{input_size}_binius_with_lookup_metrics.json");
+    write_json_metrics(&json_file, &metrics);
 
     // Run the benchmarks
-    let mut group = c.benchmark_group("sha256_2048_binius_with_lookup");
+    let mut group = c.benchmark_group(format!("sha256_{input_size}_binius_with_lookup"));
     group.sample_size(10);
     let allocator = bumpalo::Bump::new();
 
-    group.bench_function("sha256_2048_binius_with_lookup_prove", |bench| {
-        bench.iter_batched(
-            || sha256_with_lookup_prepare(&allocator),
-            |(constraint_system, args, witness, backend)| {
-                prove(constraint_system, args, witness, backend);
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    group.bench_function(
+        format!("sha256_{input_size}_binius_with_lookup_prove"),
+        |bench| {
+            bench.iter_batched(
+                || sha256_with_lookup_prepare(&allocator),
+                |(constraint_system, args, witness, backend)| {
+                    prove(constraint_system, args, witness, backend);
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
 
-    group.bench_function("sha256_2048_binius_with_lookup_verify", |bench| {
-        bench.iter_batched(
-            || {
-                let (constraint_system, args, witness, backend) =
-                    sha256_with_lookup_prepare(&allocator);
-                prove(constraint_system, args, witness, backend)
-            },
-            |(constraint_system, args, proof)| {
-                verify(constraint_system, args, proof);
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    group.bench_function(
+        format!("sha256_{input_size}_binius_with_lookup_verify"),
+        |bench| {
+            bench.iter_batched(
+                || {
+                    let (constraint_system, args, witness, backend) =
+                        sha256_with_lookup_prepare(&allocator);
+                    prove(constraint_system, args, witness, backend)
+                },
+                |(constraint_system, args, proof)| {
+                    verify(constraint_system, args, proof);
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
     group.finish();
 }
 

--- a/plonky2/benches/prove_verify.rs
+++ b/plonky2/benches/prove_verify.rs
@@ -12,47 +12,48 @@ const D: usize = 2;
 type C = PoseidonGoldilocksConfig;
 
 fn sha256_no_lookup(c: &mut Criterion) {
-    // Measure the metrics
-    let input_size = SHA2_INPUTS[0];
-    let metrics = sha256_plonky2_no_lookup_metrics(input_size);
+    for input_size in SHA2_INPUTS {
+        // Measure the metrics
+        let metrics = sha256_plonky2_no_lookup_metrics(input_size);
 
-    let json_file = format!("sha256_{input_size}_plonky2_no_lookup_metrics.json");
-    write_json_metrics(&json_file, &metrics);
+        let json_file = format!("sha256_{input_size}_plonky2_no_lookup_metrics.json");
+        write_json_metrics(&json_file, &metrics);
 
-    // Run the benchmarks
-    let mut group = c.benchmark_group(format!("sha256_{input_size}_plonky2_no_lookup"));
-    group.sample_size(10);
+        // Run the benchmarks
+        let mut group = c.benchmark_group(format!("sha256_{input_size}_plonky2_no_lookup"));
+        group.sample_size(10);
 
-    group.bench_function(
-        format!("sha256_{input_size}_plonky2_no_lookup_prove"),
-        |bench| {
-            bench.iter_batched(
-                sha256_no_lookup_prepare,
-                |(data, pw)| {
-                    prove(&data.prover_data(), pw);
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
+        group.bench_function(
+            format!("sha256_{input_size}_plonky2_no_lookup_prove"),
+            |bench| {
+                bench.iter_batched(
+                    sha256_no_lookup_prepare,
+                    |(data, pw)| {
+                        prove(&data.prover_data(), pw);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
 
-    group.bench_function(
-        format!("sha256_{input_size}_plonky2_no_lookup_verify"),
-        |bench| {
-            bench.iter_batched(
-                || {
-                    let (data, pw) = sha256_no_lookup_prepare();
-                    let verifier_data = data.verifier_data();
-                    (prove(&data.prover_data(), pw), verifier_data)
-                },
-                |(proof, data)| {
-                    verify(&data, proof);
-                },
-                BatchSize::SmallInput,
-            );
-        },
-    );
-    group.finish();
+        group.bench_function(
+            format!("sha256_{input_size}_plonky2_no_lookup_verify"),
+            |bench| {
+                bench.iter_batched(
+                    || {
+                        let (data, pw) = sha256_no_lookup_prepare();
+                        let verifier_data = data.verifier_data();
+                        (prove(&data.prover_data(), pw), verifier_data)
+                    },
+                    |(proof, data)| {
+                        verify(&data, proof);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+        group.finish();
+    }
 }
 
 criterion_main!(sha256);

--- a/plonky2/benches/prove_verify.rs
+++ b/plonky2/benches/prove_verify.rs
@@ -3,46 +3,55 @@ use plonky2_sha256::bench::{prove, sha256_no_lookup_prepare, verify};
 
 use plonky2::{plonk::config::PoseidonGoldilocksConfig, util::serialization::Write};
 use plonky2_u32::gates::arithmetic_u32::{U32GateSerializer, U32GeneratorSerializer};
-use utils::bench::{Metrics, write_json_metrics};
+use utils::{
+    bench::{Metrics, write_json_metrics},
+    metadata::SHA2_INPUTS,
+};
 
 const D: usize = 2;
 type C = PoseidonGoldilocksConfig;
 
 fn sha256_no_lookup(c: &mut Criterion) {
     // Measure the metrics
-    let input_size = 2048;
+    let input_size = SHA2_INPUTS[0];
     let metrics = sha256_plonky2_no_lookup_metrics(input_size);
 
-    let json_file = "sha256_2048_plonky2_no_lookup_metrics.json";
-    write_json_metrics(json_file, &metrics);
+    let json_file = format!("sha256_{input_size}_plonky2_no_lookup_metrics.json");
+    write_json_metrics(&json_file, &metrics);
 
     // Run the benchmarks
-    let mut group = c.benchmark_group("sha256_2048_plonky2_no_lookup");
+    let mut group = c.benchmark_group(format!("sha256_{input_size}_plonky2_no_lookup"));
     group.sample_size(10);
 
-    group.bench_function("sha256_2048_plonky2_no_lookup_prove", |bench| {
-        bench.iter_batched(
-            sha256_no_lookup_prepare,
-            |(data, pw)| {
-                prove(&data.prover_data(), pw);
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    group.bench_function(
+        format!("sha256_{input_size}_plonky2_no_lookup_prove"),
+        |bench| {
+            bench.iter_batched(
+                sha256_no_lookup_prepare,
+                |(data, pw)| {
+                    prove(&data.prover_data(), pw);
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
 
-    group.bench_function("sha256_2048_plonky2_no_lookup_verify", |bench| {
-        bench.iter_batched(
-            || {
-                let (data, pw) = sha256_no_lookup_prepare();
-                let verifier_data = data.verifier_data();
-                (prove(&data.prover_data(), pw), verifier_data)
-            },
-            |(proof, data)| {
-                verify(&data, proof);
-            },
-            BatchSize::SmallInput,
-        );
-    });
+    group.bench_function(
+        format!("sha256_{input_size}_plonky2_no_lookup_verify"),
+        |bench| {
+            bench.iter_batched(
+                || {
+                    let (data, pw) = sha256_no_lookup_prepare();
+                    let verifier_data = data.verifier_data();
+                    (prove(&data.prover_data(), pw), verifier_data)
+                },
+                |(proof, data)| {
+                    verify(&data, proof);
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
     group.finish();
 }
 

--- a/plonky3-powdr/benches/prove_verify.rs
+++ b/plonky3-powdr/benches/prove_verify.rs
@@ -6,41 +6,42 @@ use utils::{
 };
 
 fn sha256_bench(c: &mut Criterion) {
-    // Measure the SubMetrics
-    let input_size = SHA2_INPUTS[0];
-    let metrics = sha256_powdr_metrics(input_size);
+    for input_size in SHA2_INPUTS {
+        // Measure the SubMetrics
+        let metrics = sha256_powdr_metrics(input_size);
 
-    let json_file = format!("sha256_{input_size}_powdr_metrics.json");
-    write_json_metrics(&json_file, &metrics);
+        let json_file = format!("sha256_{input_size}_powdr_metrics.json");
+        write_json_metrics(&json_file, &metrics);
 
-    // Run the benchmarks
-    let mut group = c.benchmark_group(format!("sha256_{input_size}_powdr"));
-    group.sample_size(10);
+        // Run the benchmarks
+        let mut group = c.benchmark_group(format!("sha256_{input_size}_powdr"));
+        group.sample_size(10);
 
-    group.bench_function(format!("sha256_{input_size}_powdr_prove"), |bench| {
-        bench.iter_batched(
-            prepare_pipeline,
-            |mut pipeline| {
-                prove(&mut pipeline);
-            },
-            BatchSize::SmallInput,
-        );
-    });
+        group.bench_function(format!("sha256_{input_size}_powdr_prove"), |bench| {
+            bench.iter_batched(
+                prepare_pipeline,
+                |mut pipeline| {
+                    prove(&mut pipeline);
+                },
+                BatchSize::SmallInput,
+            );
+        });
 
-    group.bench_function(format!("sha256_{input_size}_powdr_verify"), |bench| {
-        bench.iter_batched(
-            || {
-                let mut pipeline = prepare_pipeline();
-                prove(&mut pipeline);
-                pipeline
-            },
-            |pipeline| {
-                verify(pipeline);
-            },
-            BatchSize::SmallInput,
-        );
-    });
-    group.finish();
+        group.bench_function(format!("sha256_{input_size}_powdr_verify"), |bench| {
+            bench.iter_batched(
+                || {
+                    let mut pipeline = prepare_pipeline();
+                    prove(&mut pipeline);
+                    pipeline
+                },
+                |pipeline| {
+                    verify(pipeline);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+        group.finish();
+    }
 }
 
 criterion_main!(sha256);

--- a/plonky3-powdr/benches/prove_verify.rs
+++ b/plonky3-powdr/benches/prove_verify.rs
@@ -1,20 +1,23 @@
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use sha::bench::{prepare_pipeline, prove, verify};
-use utils::bench::{Metrics, write_json_metrics};
+use utils::{
+    bench::{Metrics, write_json_metrics},
+    metadata::SHA2_INPUTS,
+};
 
 fn sha256_bench(c: &mut Criterion) {
     // Measure the SubMetrics
-    let input_size = 2048;
+    let input_size = SHA2_INPUTS[0];
     let metrics = sha256_powdr_metrics(input_size);
 
-    let json_file = "sha256_2048_powdr_metrics.json";
-    write_json_metrics(json_file, &metrics);
+    let json_file = format!("sha256_{input_size}_powdr_metrics.json");
+    write_json_metrics(&json_file, &metrics);
 
     // Run the benchmarks
-    let mut group = c.benchmark_group("sha256_2048_powdr");
+    let mut group = c.benchmark_group(format!("sha256_{input_size}_powdr"));
     group.sample_size(10);
 
-    group.bench_function("sha256_2048_powdr_prove", |bench| {
+    group.bench_function(format!("sha256_{input_size}_powdr_prove"), |bench| {
         bench.iter_batched(
             prepare_pipeline,
             |mut pipeline| {
@@ -24,7 +27,7 @@ fn sha256_bench(c: &mut Criterion) {
         );
     });
 
-    group.bench_function("sha256_2048_powdr_verify", |bench| {
+    group.bench_function(format!("sha256_{input_size}_powdr_verify"), |bench| {
         bench.iter_batched(
             || {
                 let mut pipeline = prepare_pipeline();

--- a/provekit/benches/prove_verify.rs
+++ b/provekit/benches/prove_verify.rs
@@ -64,5 +64,5 @@ fn sha256_provekit_metrics(bench_harness: &ProvekitSha256Benchmark, input_size: 
     let proof = bench_harness.run_prove();
     metrics.proof_size = proof.whir_r1cs_proof.transcript.len();
 
-    metricss
+    metrics
 }

--- a/provekit/benches/prove_verify.rs
+++ b/provekit/benches/prove_verify.rs
@@ -1,6 +1,5 @@
 use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
-use provekit::{ProvekitSha256Benchmark, WORKSPACE_ROOT};
-use std::path::PathBuf;
+use provekit::ProvekitSha256Benchmark;
 use utils::bench::{Metrics, write_json_metrics};
 use utils::metadata::SHA2_INPUTS;
 

--- a/provekit/benches/prove_verify.rs
+++ b/provekit/benches/prove_verify.rs
@@ -47,19 +47,7 @@ fn sha256_provekit_metrics(bench_harness: &ProvekitSha256Benchmark, input_size: 
         input_size,
     );
 
-    let package_name = format!("sha256_bench_{input_size}");
-    let circuit_path = PathBuf::from(WORKSPACE_ROOT)
-        .join("target")
-        .join(format!("{package_name}.json"));
-    let toml_path = PathBuf::from(WORKSPACE_ROOT)
-        .join("circuits/hash/sha256-provekit")
-        .join(format!("sha256-bench-{input_size}"))
-        .join("Prover.toml");
-
-    metrics.preprocessing_size = std::fs::metadata(circuit_path)
-        .map(|m| m.len())
-        .unwrap_or(0) as usize
-        + std::fs::metadata(toml_path).map(|m| m.len()).unwrap_or(0) as usize;
+    metrics.preprocessing_size = bench_harness.preprocessing_size();
 
     let proof = bench_harness.run_prove();
     metrics.proof_size = proof.whir_r1cs_proof.transcript.len();

--- a/provekit/src/bin/measure_mem.rs
+++ b/provekit/src/bin/measure_mem.rs
@@ -2,9 +2,7 @@ use provekit::ProvekitSha256Benchmark;
 use utils::metadata::SHA2_INPUTS;
 
 fn main() {
-    let bench_harness = ProvekitSha256Benchmark::new(&SHA2_INPUTS);
-
-    for &size in SHA2_INPUTS.iter() {
-        let _proof = bench_harness.run_prove(size);
-    }
+    let input_size = SHA2_INPUTS[0];
+    let bench_harness = ProvekitSha256Benchmark::new(input_size);
+    let _proof = bench_harness.run_prove();
 }

--- a/provekit/src/bin/measure_mem.rs
+++ b/provekit/src/bin/measure_mem.rs
@@ -1,8 +1,6 @@
 use provekit::ProvekitSha256Benchmark;
-use utils::metadata::SHA2_INPUTS;
 
 fn main() {
-    let input_size = SHA2_INPUTS[0];
-    let bench_harness = ProvekitSha256Benchmark::new(input_size);
+    let bench_harness = ProvekitSha256Benchmark::new(2048);
     let _proof = bench_harness.run_prove();
 }

--- a/provekit/src/lib.rs
+++ b/provekit/src/lib.rs
@@ -1,6 +1,5 @@
 use noir_r1cs::{NoirProof, NoirProofScheme};
 use rand::RngCore;
-use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -73,7 +72,7 @@ impl ProvekitSha256Benchmark {
     pub fn run_prove(&self) -> NoirProof {
         let witness_map = self
             .proof_scheme
-            .read_witness(toml_path.to_str().unwrap())
+            .read_witness(self.toml_path.to_str().unwrap())
             .expect("Failed to read witness");
 
         self.proof_scheme

--- a/provekit/src/lib.rs
+++ b/provekit/src/lib.rs
@@ -4,18 +4,22 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-pub const WORKSPACE_ROOT: &str = "circuits";
-pub const CIRCUIT_SUB_PATH: &str = "hash/sha256-provekit";
+const WORKSPACE_ROOT: &str = "circuits";
+const CIRCUIT_SUB_PATH: &str = "hash/sha256-provekit";
 
 /// Provekit benchmark harness for SHA256.
 pub struct ProvekitSha256Benchmark {
     proof_scheme: NoirProofScheme,
     toml_path: PathBuf,
+    preprocessing_size: usize,
 }
 
 impl ProvekitSha256Benchmark {
     /// Compiles the circuits and creates a new benchmark harness.
     pub fn new(input_size: usize) -> Self {
+        // Compile the workspace
+        let current_dir = std::env::current_dir().expect("Failed to get current directory");
+        let workspace_root = current_dir.join(WORKSPACE_ROOT);
         let output = Command::new("nargo")
             .args([
                 "compile",
@@ -23,7 +27,7 @@ impl ProvekitSha256Benchmark {
                 "--silence-warnings",
                 "--skip-brillig-constraints-check",
             ])
-            .current_dir(WORKSPACE_ROOT)
+            .current_dir(workspace_root)
             .output()
             .expect("Failed to run nargo compile");
 
@@ -35,10 +39,9 @@ impl ProvekitSha256Benchmark {
         }
 
         let mut rng = rand::thread_rng();
-        let workspace_path = PathBuf::from(WORKSPACE_ROOT);
 
         let package_name = format!("sha256_bench_{input_size}");
-        let circuit_path = workspace_path
+        let circuit_path = workspace_root
             .join("target")
             .join(format!("{package_name}.json"));
 
@@ -46,7 +49,7 @@ impl ProvekitSha256Benchmark {
             .unwrap_or_else(|e| panic!("Failed to load proof scheme for size {input_size}: {e}"));
 
         let dir_name = format!("sha256-bench-{input_size}");
-        let circuit_member_dir = workspace_path.join(CIRCUIT_SUB_PATH).join(dir_name);
+        let circuit_member_dir = workspace_root.join(CIRCUIT_SUB_PATH).join(dir_name);
         fs::create_dir_all(&circuit_member_dir).expect("Failed to create circuit dir");
 
         let mut data = vec![0u8; input_size];
@@ -62,9 +65,15 @@ impl ProvekitSha256Benchmark {
         let toml_path = circuit_member_dir.join("Prover.toml");
         fs::write(&toml_path, toml_content).expect("Failed to write Prover.toml");
 
+        let preprocessing_size = std::fs::metadata(circuit_path)
+            .map(|m| m.len())
+            .unwrap_or(0) as usize
+            + std::fs::metadata(toml_path).map(|m| m.len()).unwrap_or(0) as usize;
+
         Self {
             proof_scheme,
             toml_path,
+            preprocessing_size,
         }
     }
 
@@ -93,5 +102,10 @@ impl ProvekitSha256Benchmark {
         proof_scheme: &NoirProofScheme,
     ) -> Result<(), &'static str> {
         proof_scheme.verify(proof).map_err(|_| "Proof is not valid")
+    }
+
+    /// Returns the preprocessing size.
+    pub fn preprocessing_size(&self) -> usize {
+        self.preprocessing_size
     }
 }

--- a/provekit/src/lib.rs
+++ b/provekit/src/lib.rs
@@ -27,7 +27,7 @@ impl ProvekitSha256Benchmark {
                 "--silence-warnings",
                 "--skip-brillig-constraints-check",
             ])
-            .current_dir(workspace_root)
+            .current_dir(&workspace_root)
             .output()
             .expect("Failed to run nargo compile");
 
@@ -68,7 +68,7 @@ impl ProvekitSha256Benchmark {
         let preprocessing_size = std::fs::metadata(circuit_path)
             .map(|m| m.len())
             .unwrap_or(0) as usize
-            + std::fs::metadata(toml_path).map(|m| m.len()).unwrap_or(0) as usize;
+            + std::fs::metadata(&toml_path).map(|m| m.len()).unwrap_or(0) as usize;
 
         Self {
             proof_scheme,

--- a/provekit/src/lib.rs
+++ b/provekit/src/lib.rs
@@ -10,13 +10,13 @@ pub const CIRCUIT_SUB_PATH: &str = "hash/sha256-provekit";
 
 /// Provekit benchmark harness for SHA256.
 pub struct ProvekitSha256Benchmark {
-    proof_schemes: HashMap<usize, NoirProofScheme>,
-    toml_paths: HashMap<usize, PathBuf>,
+    proof_scheme: NoirProofScheme,
+    toml_path: PathBuf,
 }
 
 impl ProvekitSha256Benchmark {
     /// Compiles the circuits and creates a new benchmark harness.
-    pub fn new(input_sizes: &[usize]) -> Self {
+    pub fn new(input_size: usize) -> Self {
         let output = Command::new("nargo")
             .args([
                 "compile",
@@ -37,62 +37,54 @@ impl ProvekitSha256Benchmark {
 
         let mut rng = rand::thread_rng();
         let workspace_path = PathBuf::from(WORKSPACE_ROOT);
-        let mut proof_schemes = HashMap::new();
-        let mut toml_paths = HashMap::new();
 
-        for &size in input_sizes {
-            let package_name = format!("sha256_bench_{size}");
-            let circuit_path = workspace_path
-                .join("target")
-                .join(format!("{package_name}.json"));
+        let package_name = format!("sha256_bench_{input_size}");
+        let circuit_path = workspace_path
+            .join("target")
+            .join(format!("{package_name}.json"));
 
-            let proof_scheme = NoirProofScheme::from_file(circuit_path.to_str().unwrap())
-                .unwrap_or_else(|e| panic!("Failed to load proof scheme for size {size}: {e}"));
-            proof_schemes.insert(size, proof_scheme);
+        let proof_scheme = NoirProofScheme::from_file(circuit_path.to_str().unwrap())
+            .unwrap_or_else(|e| panic!("Failed to load proof scheme for size {input_size}: {e}"));
 
-            let dir_name = format!("sha256-bench-{size}");
-            let circuit_member_dir = workspace_path.join(CIRCUIT_SUB_PATH).join(dir_name);
-            fs::create_dir_all(&circuit_member_dir).expect("Failed to create circuit dir");
+        let dir_name = format!("sha256-bench-{input_size}");
+        let circuit_member_dir = workspace_path.join(CIRCUIT_SUB_PATH).join(dir_name);
+        fs::create_dir_all(&circuit_member_dir).expect("Failed to create circuit dir");
 
-            let mut data = vec![0u8; size];
-            rng.fill_bytes(&mut data);
-            let toml_content = format!(
-                "input = [{}]\ninput_len = {size}",
-                data.iter()
-                    .map(u8::to_string)
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            );
+        let mut data = vec![0u8; input_size];
+        rng.fill_bytes(&mut data);
+        let toml_content = format!(
+            "input = [{}]\ninput_len = {input_size}",
+            data.iter()
+                .map(u8::to_string)
+                .collect::<Vec<_>>()
+                .join(", "),
+        );
 
-            let toml_path = circuit_member_dir.join("Prover.toml");
-            fs::write(&toml_path, toml_content).expect("Failed to write Prover.toml");
-            toml_paths.insert(size, toml_path);
-        }
+        let toml_path = circuit_member_dir.join("Prover.toml");
+        fs::write(&toml_path, toml_content).expect("Failed to write Prover.toml");
 
         Self {
-            proof_schemes,
-            toml_paths,
+            proof_scheme,
+            toml_path,
         }
     }
 
     /// Runs the proving algorithm.
-    pub fn run_prove(&self, input_size: usize) -> NoirProof {
-        let proof_scheme = self.proof_schemes.get(&input_size).unwrap();
-        let toml_path = self.toml_paths.get(&input_size).unwrap();
-        let witness_map = proof_scheme
+    pub fn run_prove(&self) -> NoirProof {
+        let witness_map = self
+            .proof_scheme
             .read_witness(toml_path.to_str().unwrap())
             .expect("Failed to read witness");
 
-        proof_scheme
+        self.proof_scheme
             .prove(&witness_map)
             .expect("Proof generation failed")
     }
 
     /// Prepares inputs for verification.
-    pub fn prepare_verify(&self, input_size: usize) -> (NoirProof, &NoirProofScheme) {
-        let proof_scheme = self.proof_schemes.get(&input_size).unwrap();
-        let proof = self.run_prove(input_size);
-        (proof, proof_scheme)
+    pub fn prepare_verify(&self) -> (NoirProof, &NoirProofScheme) {
+        let proof = self.run_prove();
+        (proof, &self.proof_scheme)
     }
 
     /// Runs the verification algorithm.


### PR DESCRIPTION
## Description
Use the `utils::metadata::SHA2_INPUTS` for every benchmarks

## Related issues
Closes #33 

## Changes
- refactor the several benchmarks so that they use above 
  - `binius`, `plonky2`, `plonky3-powdr`, `provekit`
- fix the `provekit` ci failure