### PR TITLE
Update CI workflows to collect results after all workflows have finished

### DIFF
--- a/.github/workflows/collect_results.yml
+++ b/.github/workflows/collect_results.yml
@@ -1,0 +1,154 @@
+name: Collect & Parse Artifacts (fan-in)
+
+# Will be triggered by the completion of any of the following workflows:
+on:
+  workflow_run:
+    workflows:
+      [
+        "Rust Benchmarks (parallel)",
+        "Rust Benchmarks (serial)",
+        "Non-Rust Benchmarks (parallel)",
+      ]
+    types: [completed]
+
+# collapse multiple triggers for the same commit into one survivor
+concurrency:
+  group: fanin-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  collect:
+    runs-on: macos-latest
+    env:
+      SHA: ${{ github.event.workflow_run.head_sha }}
+      # keep in sync with on.workflow_run.workflows
+      REQUIRED_WORKFLOWS_JSON: '["Rust Benchmarks (parallel)", "Rust Benchmarks (serial)", "Non-Rust Benchmarks (parallel)"]'
+      WAIT_SECONDS: "30"
+      MAX_TRIES: "80" # 30 × 80 = ~40 min max wait
+    steps:
+      - uses: actions/checkout@v4
+
+      # Installation is necessary for a non-GitHub runner
+      - name: Install gh
+        run: brew install gh
+
+      - name: Install jq
+        run: brew install jq
+
+      - name: Auth gh
+        run: gh auth setup-git
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait until all parent workflows are completed for this commit
+        id: wait
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Target SHA: $SHA"
+          tries=0
+          while (( tries < MAX_TRIES )); do
+            all_done=true
+            any_failed=false
+            summary=""
+            # build array of workflow names from JSON env
+            mapfile -t WORKFLOWS < <(jq -r '.[]' <<<"$REQUIRED_WORKFLOWS_JSON")
+            for wf in "${WORKFLOWS[@]}"; do
+              # List recent runs for this workflow, pick the one matching head SHA
+              run_json=$(gh run list --workflow "$wf" --limit 50 \
+                --json databaseId,headSha,conclusion,status,displayTitle,workflowName \
+                --jq "map(select(.headSha==\"$SHA\"))[0]")
+              if [[ "$run_json" == "null" || -z "$run_json" ]]; then
+                all_done=false
+                summary+="$wf: pending (not started)\n"
+                continue
+              fi
+              status=$(jq -r '.status' <<<"$run_json")
+              conclusion=$(jq -r '.conclusion' <<<"$run_json")
+              run_id=$(jq -r '.databaseId' <<<"$run_json")
+              summary+="$wf: status=$status conclusion=$conclusion run_id=$run_id\n"
+              if [[ "$status" != "completed" ]]; then
+                all_done=false
+              elif [[ "$conclusion" != "success" ]]; then
+                any_failed=true
+              fi
+            done
+            echo -e "$summary"
+            if $all_done; then
+              if $any_failed; then
+                echo "One or more parents failed. Proceeding to collect what is available."
+              else
+                echo "All parents completed successfully."
+              fi
+              break
+            fi
+            tries=$((tries+1))
+            sleep "$WAIT_SECONDS"
+          done
+          if (( tries >= MAX_TRIES )); then
+            echo "Timeout waiting for parent workflows." >&2
+            exit 1
+          fi
+
+      - name: Download artifacts from each parent run
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p inbox
+          mapfile -t WORKFLOWS < <(jq -r '.[]' <<<"$REQUIRED_WORKFLOWS_JSON")
+          for wf in "${WORKFLOWS[@]}"; do
+            RUN_ID=$(gh run list --workflow "$wf" --limit 50 \
+              --json databaseId,headSha \
+              --jq "map(select(.headSha==\"$SHA\"))[0].databaseId")
+            [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]] && { echo "No run for $wf (skipping)"; continue; }
+            gh run download "$RUN_ID" --dir "inbox/$wf" || echo "No artifacts to download for $wf (run_id=$RUN_ID). Continuing."
+          done
+
+      - name: Stage downloaded artifacts into workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          # 1) Merge all criterion trees into ./target/criterion so the collector finds them
+          mkdir -p target/criterion
+          while IFS= read -r -d '' critdir; do
+            rsync -a "$critdir"/ target/criterion/
+          done < <(find inbox -type d -path '*/target/criterion' -print0)
+
+          # 2) Restore non-Rust metrics into workspace, preserving relative paths
+          while IFS= read -r -d '' outdir; do
+            rsync -a "$outdir"/ ./
+          done < <(find inbox -type d -name 'benchmark-outputs-*' -print0)
+
+          # 3) Restore Rust metrics into workspace, preserving relative paths
+          while IFS= read -r -d '' mdir; do
+            rsync -a "$mdir"/ ./
+          done < <(find inbox -type d -name 'metrics-*' -print0)
+
+      - name: Install Rust toolchain (stable)
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+
+      - name: Build utils
+        run: cargo build --release -p utils
+
+      - name: Collect benchmarks
+        run: |
+          cd utils
+          cargo run --release --bin collect_benchmarks
+
+      - name: Upload collected reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: "collected-benchmarks"
+          path: ./collected_benchmarks.json
+          retention-days: 30

--- a/.github/workflows/collect_results.yml
+++ b/.github/workflows/collect_results.yml
@@ -3,12 +3,7 @@ name: Collect & Parse Artifacts (fan-in)
 # Will be triggered by the completion of any of the following workflows:
 on:
   workflow_run:
-    workflows:
-      [
-        "Rust Benchmarks (parallel)",
-        "Rust Benchmarks (serial)",
-        "Non-Rust Benchmarks (parallel)",
-      ]
+    workflows: ["Rust Benchmarks (parallel)", "Non-Rust Benchmarks (parallel)"]
     types: [completed]
 
 # collapse multiple triggers for the same commit into one survivor
@@ -26,7 +21,7 @@ jobs:
     env:
       SHA: ${{ github.event.workflow_run.head_sha }}
       # keep in sync with on.workflow_run.workflows
-      REQUIRED_WORKFLOWS_JSON: '["Rust Benchmarks (parallel)", "Rust Benchmarks (serial)", "Non-Rust Benchmarks (parallel)"]'
+      REQUIRED_WORKFLOWS_JSON: '["Rust Benchmarks (parallel)", "Non-Rust Benchmarks (parallel)"]'
       WAIT_SECONDS: "30"
       MAX_TRIES: "80" # 30 × 80 = ~40 min max wait
     steps:

--- a/.github/workflows/collect_results.yml
+++ b/.github/workflows/collect_results.yml
@@ -122,11 +122,12 @@ jobs:
           set -x
           shopt -s nullglob
 
-          # 1) Merge all criterion trees into ./target/criterion so the collector finds them
+          # 1) Merge all Criterion artifact trees (named criterion-<crate>, see rust_benchmarks_parallel.yml) into ./target/criterion
           mkdir -p target/criterion
-          while IFS= read -r -d '' critdir; do
-            rsync -a "$critdir"/ target/criterion/
-          done < <(find inbox -type d -path '*/target/criterion' -print0)
+          while IFS= read -r -d '' critroot; do
+            echo "Merging Criterion artifact: $critroot -> target/criterion"
+            rsync -a "$critroot"/ target/criterion/
+          done < <(find inbox -type d -maxdepth 3 -name 'criterion-*' -print0)
 
           # 2) Restore non-Rust metrics into their system folders (e.g., ./ligetron/*.json)
           while IFS= read -r -d '' outdir; do

--- a/.github/workflows/collect_results.yml
+++ b/.github/workflows/collect_results.yml
@@ -58,9 +58,8 @@ jobs:
             all_done=true
             any_failed=false
             summary=""
-            # build array of workflow names from JSON env
-            mapfile -t WORKFLOWS < <(jq -r '.[]' <<<"$REQUIRED_WORKFLOWS_JSON")
-            for wf in "${WORKFLOWS[@]}"; do
+          # Iterate workflows from JSON (compatible with macOS bash 3.2)
+          while IFS= read -r wf; do
               # List recent runs for this workflow, pick the one matching head SHA
               run_json=$(gh run list --workflow "$wf" --limit 50 \
                 --json databaseId,headSha,conclusion,status,displayTitle,workflowName \
@@ -79,7 +78,7 @@ jobs:
               elif [[ "$conclusion" != "success" ]]; then
                 any_failed=true
               fi
-            done
+          done < <(jq -r '.[]' <<<"$REQUIRED_WORKFLOWS_JSON")
             echo -e "$summary"
             if $all_done; then
               if $any_failed; then
@@ -102,14 +101,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p inbox
-          mapfile -t WORKFLOWS < <(jq -r '.[]' <<<"$REQUIRED_WORKFLOWS_JSON")
-          for wf in "${WORKFLOWS[@]}"; do
+          while IFS= read -r wf; do
             RUN_ID=$(gh run list --workflow "$wf" --limit 50 \
               --json databaseId,headSha \
               --jq "map(select(.headSha==\"$SHA\"))[0].databaseId")
             [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]] && { echo "No run for $wf (skipping)"; continue; }
             gh run download "$RUN_ID" --dir "inbox/$wf" || echo "No artifacts to download for $wf (run_id=$RUN_ID). Continuing."
-          done
+          done < <(jq -r '.[]' <<<"$REQUIRED_WORKFLOWS_JSON")
 
       - name: Stage downloaded artifacts into workspace
         shell: bash

--- a/.github/workflows/collect_results.yml
+++ b/.github/workflows/collect_results.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: macos-latest
     env:
       SHA: ${{ inputs.sha || github.event.workflow_run.head_sha || github.sha }}
+      GH_TOKEN: ${{ github.token }}
       # keep in sync with on.workflow_run.workflows
       REQUIRED_WORKFLOWS_JSON: ${{ inputs.required_workflows_json || '["Rust Benchmarks (parallel)", "Non-Rust Benchmarks (parallel)"]' }}
       WAIT_SECONDS: "30"

--- a/.github/workflows/collect_results.yml
+++ b/.github/workflows/collect_results.yml
@@ -153,6 +153,18 @@ jobs:
             fi
           done < <(find inbox -type d -name 'metrics-*' -print0)
 
+          # 4) Restore Rust mem reports into their crate folders
+          while IFS= read -r -d '' mdir; do
+            crate="$(basename "$mdir")"
+            crate="${crate#mem-}"
+            mkdir -p "$crate"
+            if [[ -d "$mdir/$crate" ]]; then
+              cp -a "$mdir/$crate/"*_mem_report.json "$crate"/ || true
+            else
+              cp -a "$mdir/"*_mem_report.json "$crate"/ || true
+            fi
+          done < <(find inbox -type d -name 'mem-*' -print0)
+
           set +x
           echo "Workspace metrics discovered (depth 2):"
           find . -maxdepth 2 -name "*_metrics.json" -print | sed 's/^/  /'

--- a/.github/workflows/collect_results.yml
+++ b/.github/workflows/collect_results.yml
@@ -5,10 +5,18 @@ on:
   workflow_run:
     workflows: ["Rust Benchmarks (parallel)", "Non-Rust Benchmarks (parallel)"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to collect from"
+        required: false
+      required_workflows_json:
+        description: "JSON array of workflow names"
+        required: false
 
 # collapse multiple triggers for the same commit into one survivor
 concurrency:
-  group: fanin-${{ github.event.workflow_run.head_sha }}
+  group: fanin-${{ inputs.sha || github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: true
 
 permissions:
@@ -19,9 +27,9 @@ jobs:
   collect:
     runs-on: macos-latest
     env:
-      SHA: ${{ github.event.workflow_run.head_sha }}
+      SHA: ${{ inputs.sha || github.event.workflow_run.head_sha || github.sha }}
       # keep in sync with on.workflow_run.workflows
-      REQUIRED_WORKFLOWS_JSON: '["Rust Benchmarks (parallel)", "Non-Rust Benchmarks (parallel)"]'
+      REQUIRED_WORKFLOWS_JSON: ${{ inputs.required_workflows_json || '["Rust Benchmarks (parallel)", "Non-Rust Benchmarks (parallel)"]' }}
       WAIT_SECONDS: "30"
       MAX_TRIES: "80" # 30 × 80 = ~40 min max wait
     steps:

--- a/.github/workflows/collect_results.yml
+++ b/.github/workflows/collect_results.yml
@@ -102,18 +102,24 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p inbox
+          echo "Downloading artifacts for workflows listed in REQUIRED_WORKFLOWS_JSON: $REQUIRED_WORKFLOWS_JSON"
           while IFS= read -r wf; do
             RUN_ID=$(gh run list --workflow "$wf" --limit 50 \
               --json databaseId,headSha \
               --jq "map(select(.headSha==\"$SHA\"))[0].databaseId")
             [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]] && { echo "No run for $wf (skipping)"; continue; }
+            echo "Downloading artifacts for $wf (run_id=$RUN_ID) into inbox/$wf"
             gh run download "$RUN_ID" --dir "inbox/$wf" || echo "No artifacts to download for $wf (run_id=$RUN_ID). Continuing."
           done < <(jq -r '.[]' <<<"$REQUIRED_WORKFLOWS_JSON")
+
+          echo "Artifact directory structure (depth 3):"
+          find inbox -maxdepth 3 -print | sed 's/^/  /'
 
       - name: Stage downloaded artifacts into workspace
         shell: bash
         run: |
           set -euo pipefail
+          set -x
           shopt -s nullglob
 
           # 1) Merge all criterion trees into ./target/criterion so the collector finds them
@@ -122,15 +128,35 @@ jobs:
             rsync -a "$critdir"/ target/criterion/
           done < <(find inbox -type d -path '*/target/criterion' -print0)
 
-          # 2) Restore non-Rust metrics into workspace, preserving relative paths
+          # 2) Restore non-Rust metrics into their system folders (e.g., ./ligetron/*.json)
           while IFS= read -r -d '' outdir; do
-            rsync -a "$outdir"/ ./
+            sys="$(basename "$outdir")"
+            sys="${sys#benchmark-outputs-}"
+            mkdir -p "$sys"
+            if [[ -d "$outdir/$sys" ]]; then
+              cp -a "$outdir/$sys/"*_metrics.json "$sys"/ || true
+            else
+              cp -a "$outdir/"*_metrics.json "$sys"/ || true
+            fi
           done < <(find inbox -type d -name 'benchmark-outputs-*' -print0)
 
-          # 3) Restore Rust metrics into workspace, preserving relative paths
+          # 3) Restore Rust metrics into their crate folders
           while IFS= read -r -d '' mdir; do
-            rsync -a "$mdir"/ ./
+            crate="$(basename "$mdir")"
+            crate="${crate#metrics-}"
+            mkdir -p "$crate"
+            if [[ -d "$mdir/$crate" ]]; then
+              cp -a "$mdir/$crate/"*_metrics.json "$crate"/ || true
+            else
+              cp -a "$mdir/"*_metrics.json "$crate"/ || true
+            fi
           done < <(find inbox -type d -name 'metrics-*' -print0)
+
+          set +x
+          echo "Workspace metrics discovered (depth 2):"
+          find . -maxdepth 2 -name "*_metrics.json" -print | sed 's/^/  /'
+          echo "Criterion entries present:"
+          find target/criterion -maxdepth 2 -type d -print 2>/dev/null | sed 's/^/  /' || true
 
       - name: Install Rust toolchain (stable)
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/dispatch_benchmarks.yml
+++ b/.github/workflows/dispatch_benchmarks.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Dispatch Rust Benchmarks (parallel)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail
@@ -49,7 +49,7 @@ jobs:
 
       - name: Dispatch Non-Rust Benchmarks (parallel)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/dispatch_benchmarks.yml
+++ b/.github/workflows/dispatch_benchmarks.yml
@@ -1,12 +1,11 @@
 name: Dispatch All Benchmarks (manual)
 
-"on":
+on:
   workflow_dispatch:
     inputs:
       ref:
         description: "Git ref (branch, tag, or SHA) to run on"
         required: false
-        default: "${{ github.ref }}"
       run_all:
         description: "Force running all benches regardless of changes"
         required: false

--- a/.github/workflows/dispatch_benchmarks.yml
+++ b/.github/workflows/dispatch_benchmarks.yml
@@ -1,0 +1,61 @@
+name: Dispatch All Benchmarks (manual)
+
+"on":
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (branch, tag, or SHA) to run on"
+        required: false
+        default: "${{ github.ref }}"
+      run_all:
+        description: "Force running all benches regardless of changes"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: macos-latest
+    steps:
+      - name: Install gh
+        run: brew install gh
+
+      - name: Determine ref
+        id: ref
+        shell: bash
+        run: |
+          set -euo pipefail
+          REF_INPUT="${{ github.event.inputs.ref }}"
+          if [[ -n "$REF_INPUT" ]]; then
+            echo "ref=$REF_INPUT" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dispatch Rust Benchmarks (parallel)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          REF='${{ steps.ref.outputs.ref }}'
+          RUN_ALL='${{ github.event.inputs.run_all }}'
+          gh workflow run "Rust Benchmarks (parallel)" \
+            --ref "$REF" \
+            -f run_all="$RUN_ALL"
+
+      - name: Dispatch Non-Rust Benchmarks (parallel)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          REF='${{ steps.ref.outputs.ref }}'
+          RUN_ALL='${{ github.event.inputs.run_all }}'
+          gh workflow run "Non-Rust Benchmarks (parallel)" \
+            --ref "$REF" \
+            -f run_all="$RUN_ALL"

--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -202,15 +202,11 @@ jobs:
           path: ./target/criterion
           retention-days: 30
 
-      - name: Collect benchmarks
-        run: |
-          cd utils
-          cargo run --release --bin collect_benchmarks
-
-      - name: Upload collected reports
+      - name: Upload metrics for ${{ matrix.crate }}
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: "collected-benchmarks-${{ matrix.crate }}"
-          path: ./collected_benchmarks.json
+          name: "metrics-${{ matrix.crate }}"
+          path: ${{ matrix.crate }}/*_metrics.json
+          if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -200,6 +200,7 @@ jobs:
         with:
           name: "criterion-${{ matrix.crate }}"
           path: ./target/criterion
+          if-no-files-found: warn
           retention-days: 30
 
       - name: Upload metrics for ${{ matrix.crate }}
@@ -208,5 +209,15 @@ jobs:
         with:
           name: "metrics-${{ matrix.crate }}"
           path: ${{ matrix.crate }}/**/*_metrics.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload mem reports for ${{ matrix.crate }}
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: "mem-${{ matrix.crate }}"
+          path: |
+            ${{ matrix.crate }}/*_mem_report.json
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -207,6 +207,6 @@ jobs:
         if: always()
         with:
           name: "metrics-${{ matrix.crate }}"
-          path: ${{ matrix.crate }}/*_metrics.json
+          path: ${{ matrix.crate }}/**/*_metrics.json
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/rust_benchmarks_serial.yml
+++ b/.github/workflows/rust_benchmarks_serial.yml
@@ -100,15 +100,11 @@ jobs:
           path: ./target/criterion
           retention-days: 30
 
-      - name: Collect benchmarks
-        run: |
-          cd utils
-          cargo run --release --bin collect_benchmarks
-
-      - name: Upload collected reports
+      - name: Upload Rust metrics
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: collected-benchmarks
-          path: ./collected_benchmarks.json
+          name: metrics-rust
+          path: "**/*_metrics.json"
+          if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/rust_benchmarks_serial.yml
+++ b/.github/workflows/rust_benchmarks_serial.yml
@@ -98,6 +98,7 @@ jobs:
         with:
           name: criterion-reports
           path: ./target/criterion
+          if-no-files-found: warn
           retention-days: 30
 
       - name: Upload Rust metrics
@@ -106,5 +107,14 @@ jobs:
         with:
           name: metrics-rust
           path: "**/*_metrics.json"
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Upload Rust mem reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mem-rust
+          path: "**/*_mem_report.json"
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/sh_benchmarks_parallel.yml
+++ b/.github/workflows/sh_benchmarks_parallel.yml
@@ -149,16 +149,3 @@ jobs:
             ${{ matrix.folder }}/*_metrics.json
           if-no-files-found: warn
           retention-days: 30
-
-      - name: Collect benchmarks
-        run: |
-          cd utils
-          cargo run --release --bin collect_benchmarks
-
-      - name: Upload collected reports
-        uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: "collected-benchmarks-${{ matrix.folder }}"
-          path: ./collected_benchmarks.json
-          retention-days: 30

--- a/circom/README.md
+++ b/circom/README.md
@@ -2,7 +2,7 @@
 
 This benchmark code is from: https://github.com/brevis-network/zk-benchmark/tree/main/circom
 
-# Run SHA256 benches
+## Run SHA256 benches
 
 ```bash
 chmod +x ../measure_mem_avg.sh

--- a/ligetron/README.md
+++ b/ligetron/README.md
@@ -15,8 +15,9 @@ cd ligetron
 
 ## Benchmarking
 
+From the root directory:
+
 ```bash
-cd ../
 cargo build --release -p utils
 ./benchmark.sh
 ```


### PR DESCRIPTION
Resolves #76.
The workflow won't run on this PR as the new result collection workflow is not yet in the default branch. I have extensively tested the workflow in my fork. Here are some examples:
- successful run when all benchmarks correctly uploaded their results: https://github.com/alxkzmn/csp-benchmarks/actions/runs/18217989010
- successful run when some reports are missing (RAM report upload was missing in Rust benchmarks, I have fixed it): https://github.com/alxkzmn/csp-benchmarks/actions/runs/18217714668/job/51870587994
The result collector now skips files if any are missing.