### PR TITLE
Add EthProofs deployment GH workflow

### DIFF
--- a/.github/workflows/supabase_upload.yml
+++ b/.github/workflows/supabase_upload.yml
@@ -6,6 +6,9 @@ on:
       run_id:
         description: "Workflow run ID containing the collected-benchmarks artifact"
         required: true
+  workflow_run:
+    workflows: ["Collect & Parse Artifacts (fan-in)"]
+    types: [completed]
 
 permissions:
   actions: read
@@ -28,7 +31,7 @@ jobs:
         with:
           name: collected-benchmarks
           path: ./artifacts
-          run-id: ${{ inputs.run_id }}
+          run-id: ${{ inputs.run_id || github.event.workflow_run.id }}
           github-token: ${{ secrets.GH_PAT }}
 
       - name: Show files
@@ -59,7 +62,8 @@ jobs:
             exit 1
           fi
           DATA=$(cat "${BENCH_JSON}")
+          RUN_ID="${{ inputs.run_id || github.event.workflow_run.id }}"
           curl -sS --fail-with-body -X POST https://ethproofs.org/api/v0/csp-benchmarks/upload \
              -H "Authorization: Bearer ${API_KEY}" \
              -F "file=@${BENCH_JSON}" \
-             -F "filename=collected-benchmarks-${{ inputs.run_id }}"
+             -F "filename=collected-benchmarks-${RUN_ID}"

--- a/.github/workflows/supabase_upload.yml
+++ b/.github/workflows/supabase_upload.yml
@@ -62,4 +62,4 @@ jobs:
           curl -X POST https://ethproofs.org/api/v0/csp-benchmarks/upload \
              -H "Authorization: Bearer ${API_KEY}" \
              -F "file=@${BENCH_JSON}" \
-             -F "filename=collected-benchmarks-${{ inputs.run_id }}.json"
+             -F "filename=collected-benchmarks-${{ inputs.run_id }}"

--- a/.github/workflows/supabase_upload.yml
+++ b/.github/workflows/supabase_upload.yml
@@ -1,0 +1,61 @@
+name: Upload Results to Supabase
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Workflow run ID containing the collected-benchmarks artifact"
+        required: true
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  upload-benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (optional if artifact only)
+        uses: actions/checkout@v4
+
+      - name: Install jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y jq
+
+      - name: Download collected-benchmarks artifact from specified run
+        uses: actions/download-artifact@v5
+        with:
+          name: collected-benchmarks
+          path: ./artifacts
+          run-id: ${{ inputs.run_id }}
+          github-token: ${{ secrets.GH_PAT }}
+
+      - name: Show files
+        run: ls -al ./artifacts
+
+      - name: Validate JSON
+        run: |
+          set -euo pipefail
+          BENCH_JSON=$(find ./artifacts -type f -name 'collected_benchmarks.json' | head -n1)
+          if [ -z "${BENCH_JSON}" ]; then
+            echo "collected_benchmarks.json not found in ./artifacts" >&2
+            exit 1
+          fi
+          jq . < "${BENCH_JSON}" > /dev/null
+
+      - name: Upload Payload
+        env:
+          API_KEY: ${{ secrets.ETHPROOFS_API_KEY }}
+        run: |
+          set -euo pipefail
+          BENCH_JSON=$(find ./artifacts -type f -name 'collected_benchmarks.json' | head -n1)
+          if [ -z "${BENCH_JSON}" ]; then
+            echo "collected_benchmarks.json not found in ./artifacts" >&2
+            exit 1
+          fi
+          DATA=$(cat "${BENCH_JSON}")
+          curl -X POST https://ethproofs.org/api/v0/csp-benchmarks/upload \
+             -H "Authorization: Bearer ${API_KEY}" \
+             -F "file=@${BENCH_JSON}" \
+             -F "filename=collected-benchmarks-${{ inputs.run_id }}.json"

--- a/.github/workflows/supabase_upload.yml
+++ b/.github/workflows/supabase_upload.yml
@@ -59,7 +59,7 @@ jobs:
             exit 1
           fi
           DATA=$(cat "${BENCH_JSON}")
-          curl -X POST https://ethproofs.org/api/v0/csp-benchmarks/upload \
+          RESPONSE=$(curl -sS --fail-with-body -X POST https://ethproofs.org/api/v0/csp-benchmarks/upload \
              -H "Authorization: Bearer ${API_KEY}" \
              -F "file=@${BENCH_JSON}" \
-             -F "filename=collected-benchmarks-${{ inputs.run_id }}"
+             -F "filename=collected-benchmarks-${{ inputs.run_id }}..."

--- a/.github/workflows/supabase_upload.yml
+++ b/.github/workflows/supabase_upload.yml
@@ -59,7 +59,7 @@ jobs:
             exit 1
           fi
           DATA=$(cat "${BENCH_JSON}")
-          RESPONSE=$(curl -sS --fail-with-body -X POST https://ethproofs.org/api/v0/csp-benchmarks/upload \
+          curl -sS --fail-with-body -X POST https://ethproofs.org/api/v0/csp-benchmarks/upload \
              -H "Authorization: Bearer ${API_KEY}" \
              -F "file=@${BENCH_JSON}" \
              -F "filename=collected-benchmarks-${{ inputs.run_id }}..."

--- a/.github/workflows/supabase_upload.yml
+++ b/.github/workflows/supabase_upload.yml
@@ -49,6 +49,10 @@ jobs:
           API_KEY: ${{ secrets.ETHPROOFS_API_KEY }}
         run: |
           set -euo pipefail
+          if [ -z "${API_KEY:-}" ]; then
+            echo "ETHPROOFS_API_KEY secret is not set; aborting." >&2
+            exit 1
+          fi
           BENCH_JSON=$(find ./artifacts -type f -name 'collected_benchmarks.json' | head -n1)
           if [ -z "${BENCH_JSON}" ]; then
             echo "collected_benchmarks.json not found in ./artifacts" >&2

--- a/.github/workflows/supabase_upload.yml
+++ b/.github/workflows/supabase_upload.yml
@@ -62,4 +62,4 @@ jobs:
           curl -sS --fail-with-body -X POST https://ethproofs.org/api/v0/csp-benchmarks/upload \
              -H "Authorization: Bearer ${API_KEY}" \
              -F "file=@${BENCH_JSON}" \
-             -F "filename=collected-benchmarks-${{ inputs.run_id }}..."
+             -F "filename=collected-benchmarks-${{ inputs.run_id }}"


### PR DESCRIPTION
- https://github.com/ethproofs/ethproofs/pull/522 added the upload API implementation;
- API endpoint requires auth key that I've added into repo secrets; 
- As usual, I had to test the new action in my fork: https://github.com/alxkzmn/csp-benchmarks/actions/runs/18456071911/job/52577591285
- It will run automatically after the result collection workflow, we can set up some kind of stage-prod Git workflow later to make sure we don't upload to prod EthProofs every time when we merge (to be discussed with EthProofs).