### PR TITLE
Run all benchmarks and upload to EthProofs only on PR merge

### DIFF
--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -56,6 +56,11 @@ jobs:
           BASE_REF="${{ steps.base.outputs.BASE_REF }}"
 
           RUN_ALL="${{ github.event.inputs.run_all }}"
+          # ─── Run all benches when we're merging a PR ─────────────────────
+          EVENT_NAME='${{ github.event_name }}'
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            RUN_ALL="true"
+          fi
 
           EXCLUDE_REGEX='^(utils|mobile|zkvm)(/|$)'
 

--- a/.github/workflows/sh_benchmarks_parallel.yml
+++ b/.github/workflows/sh_benchmarks_parallel.yml
@@ -66,15 +66,13 @@ jobs:
 
           # ─── 1. list of top‑level folders to watch ────────────
           FOLDERS=(
-            ligetron,
+            ligetron
             barretenberg
           )
 
           # ─── 2. filter by diff (or include all when run_all=true) ───────
           changed=()
           for d in "${FOLDERS[@]}"; do
-            # skip if directory does not exist in the workspace
-            [[ -d "$d" ]] || continue
 
             if [[ "$RUN_ALL" == "true" ]]; then
               changed+=("$d")

--- a/.github/workflows/sh_benchmarks_parallel.yml
+++ b/.github/workflows/sh_benchmarks_parallel.yml
@@ -58,6 +58,11 @@ jobs:
           BASE_REF="${{ steps.base.outputs.BASE_REF }}"
 
           RUN_ALL="${{ github.event.inputs.run_all }}"
+          # ─── Run all benches when we're merging a PR ─────────────────────
+          EVENT_NAME='${{ github.event_name }}'
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            RUN_ALL="true"
+          fi
 
           # ─── 1. list of top‑level folders to watch ────────────
           FOLDERS=(

--- a/.github/workflows/supabase_upload.yml
+++ b/.github/workflows/supabase_upload.yml
@@ -6,9 +6,6 @@ on:
       run_id:
         description: "Workflow run ID containing the collected-benchmarks artifact"
         required: true
-  workflow_run:
-    workflows: ["Collect & Parse Artifacts (fan-in)"]
-    types: [completed]
 
 permissions:
   actions: read
@@ -16,7 +13,6 @@ permissions:
 
 jobs:
   upload-benchmarks:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'CSP-Q3-2025') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (optional if artifact only)
@@ -27,12 +23,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y jq
 
-      - name: Download collected-benchmarks artifact from specified run
+      - name: Download collected-benchmarks artifact
         uses: actions/download-artifact@v5
         with:
           name: collected-benchmarks
           path: ./artifacts
-          run-id: ${{ inputs.run_id || github.event.workflow_run.id }}
+          run-id: ${{ inputs.run_id }}
           github-token: ${{ secrets.GH_PAT }}
 
       - name: Show files
@@ -63,7 +59,7 @@ jobs:
             exit 1
           fi
           DATA=$(cat "${BENCH_JSON}")
-          RUN_ID="${{ inputs.run_id || github.event.workflow_run.id }}"
+          RUN_ID="${{ inputs.run_id }}"
           curl -sS --fail-with-body -X POST https://deploy-preview-524--ethproofs.netlify.app/api/v0/csp-benchmarks/upload \
              -H "Authorization: Bearer ${API_KEY}" \
              -F "file=@${BENCH_JSON}" \

--- a/.github/workflows/supabase_upload.yml
+++ b/.github/workflows/supabase_upload.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   upload-benchmarks:
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'CSP-Q3-2025') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (optional if artifact only)
@@ -64,7 +64,7 @@ jobs:
           fi
           DATA=$(cat "${BENCH_JSON}")
           RUN_ID="${{ inputs.run_id || github.event.workflow_run.id }}"
-          curl -sS --fail-with-body -X POST https://ethproofs.org/api/v0/csp-benchmarks/upload \
+          curl -sS --fail-with-body -X POST https://deploy-preview-524--ethproofs.netlify.app/api/v0/csp-benchmarks/upload \
              -H "Authorization: Bearer ${API_KEY}" \
              -F "file=@${BENCH_JSON}" \
              -F "filename=collected-benchmarks-${RUN_ID}"

--- a/.github/workflows/supabase_upload.yml
+++ b/.github/workflows/supabase_upload.yml
@@ -3,6 +3,14 @@ name: Upload Results to Supabase
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        description: "Environment to upload to"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - prod
       run_id:
         description: "Workflow run ID containing the collected-benchmarks artifact"
         required: true
@@ -46,9 +54,17 @@ jobs:
 
       - name: Upload Payload
         env:
-          API_KEY: ${{ secrets.ETHPROOFS_DEV_KEY }}
+          DEV_API_KEY: ${{ secrets.ETHPROOFS_DEV_KEY }}
+          PROD_API_KEY: ${{ secrets.ETHPROOFS_API_KEY }}
         run: |
           set -euo pipefail
+          if [ "${{ inputs.environment }}" = "dev" ]; then
+            API_KEY="${DEV_API_KEY}"
+            API_URL="https://deploy-preview-524--ethproofs.netlify.app/api/v0/csp-benchmarks/upload"
+          else
+            API_KEY="${PROD_API_KEY}"
+            API_URL="https://ethproofs.net/api/v0/csp-benchmarks/upload"
+          fi
           if [ -z "${API_KEY:-}" ]; then
             echo "ETHPROOFS_DEV_KEY secret is not set; aborting." >&2
             exit 1
@@ -60,7 +76,7 @@ jobs:
           fi
           DATA=$(cat "${BENCH_JSON}")
           RUN_ID="${{ inputs.run_id }}"
-          curl -sS --fail-with-body -X POST https://deploy-preview-524--ethproofs.netlify.app/api/v0/csp-benchmarks/upload \
+          curl -sS --fail-with-body -X POST ${API_URL} \
              -H "Authorization: Bearer ${API_KEY}" \
              -F "file=@${BENCH_JSON}" \
              -F "filename=collected-benchmarks-${RUN_ID}"

--- a/.github/workflows/supabase_upload.yml
+++ b/.github/workflows/supabase_upload.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   upload-benchmarks:
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (optional if artifact only)
@@ -49,11 +50,11 @@ jobs:
 
       - name: Upload Payload
         env:
-          API_KEY: ${{ secrets.ETHPROOFS_API_KEY }}
+          API_KEY: ${{ secrets.ETHPROOFS_DEV_KEY }}
         run: |
           set -euo pipefail
           if [ -z "${API_KEY:-}" ]; then
-            echo "ETHPROOFS_API_KEY secret is not set; aborting." >&2
+            echo "ETHPROOFS_DEV_KEY secret is not set; aborting." >&2
             exit 1
           fi
           BENCH_JSON=$(find ./artifacts -type f -name 'collected_benchmarks.json' | head -n1)

--- a/utils/src/metadata.rs
+++ b/utils/src/metadata.rs
@@ -1,1 +1,1 @@
-pub const SHA2_INPUTS: [usize; 1] = [128];
+pub const SHA2_INPUTS: [usize; 2] = [128, 256];


### PR DESCRIPTION
Check the test upload here (use the drop-down at the top right to select the latest results): https://deploy-preview-524--ethproofs.netlify.app/csp-benchmarks
Results uploaded from a run in my fork (https://github.com/alxkzmn/csp-benchmarks/actions/runs/18661184728)

- Run all benches on PR merge to CSP-Q3-2025
- Fix non-Rust bench folder names parsing in the workflow
- Add environment selector for EthProofs upload (prod/dev)
- Switch to manual upload - we only upload the necessary run results.
- Note: Circom bench is failing because it has only one hardcoded circuit, to be solved in #100 