### PR TITLE
Set full SHA256 input range; skip optional benchmarks

### DIFF
--- a/.github/workflows/dispatch_benchmarks.yml
+++ b/.github/workflows/dispatch_benchmarks.yml
@@ -11,6 +11,11 @@ on:
         required: false
         default: true
         type: boolean
+      include_optional:
+        description: "Include the mobile-unfriendly systems (openvm, jolt, sp1)"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: write
@@ -46,9 +51,11 @@ jobs:
           set -euo pipefail
           REF='${{ steps.ref.outputs.ref }}'
           RUN_ALL='${{ github.event.inputs.run_all }}'
+          INCLUDE_OPTIONAL='${{ github.event.inputs.include_optional }}'
           gh workflow run "Rust Benchmarks (parallel)" \
             --ref "$REF" \
-            -f run_all="$RUN_ALL"
+            -f run_all="$RUN_ALL" \
+            -f include_optional="$INCLUDE_OPTIONAL"
 
       - name: Dispatch Non-Rust Benchmarks (parallel)
         env:

--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: false
         type: boolean
+      include_optional:
+        description: "Include the mobile-unfriendly systems (openvm, jolt, sp1)"
+        required: false
+        default: false
+        type: boolean
 
 env:
   CARGO_TERM_COLOR: always
@@ -56,6 +61,7 @@ jobs:
           BASE_REF="${{ steps.base.outputs.BASE_REF }}"
 
           RUN_ALL="${{ github.event.inputs.run_all }}"
+          INCLUDE_OPTIONAL="${{ github.event.inputs.include_optional }}"
           # ─── Run all benches when we're merging a PR ─────────────────────
           EVENT_NAME='${{ github.event_name }}'
           if [[ "$EVENT_NAME" == "push" ]]; then
@@ -94,6 +100,17 @@ jobs:
               changed+=("$d")
             fi
           done
+
+          # ─── 3.5 exclude optional crates unless explicitly included ────
+          if [[ "$INCLUDE_OPTIONAL" != "true" ]]; then
+            filtered=()
+            for d in "${changed[@]}"; do
+              if [[ ! "$d" =~ ^(openvm|jolt|sp1)(/|$) ]]; then
+                filtered+=("$d")
+              fi
+            done
+            changed=("${filtered[@]}")
+          fi
 
           # ─── 4. output JSON array ───────────────────────────────────────
           json=$(printf '%s\n' "${changed[@]}" |
@@ -142,6 +159,7 @@ jobs:
           components: llvm-tools, rustc-dev, rust-src, rustfmt, clippy
 
       - name: Install OpenVM
+        if: ${{ github.event.inputs.include_optional == true }}
         uses: ./.github/actions/install-openvm
       - name: Install OpenMPI for polyhedra-expander
         uses: ./.github/actions/install-ompi
@@ -150,13 +168,20 @@ jobs:
         uses: ./.github/actions/install-risc0
 
       - name: Install SP1 toolchain
+        if: ${{ github.event.inputs.include_optional == true }}
         uses: ./.github/actions/install-sp1
 
       - name: Install LLVM and LLD for cairo-m
         uses: ./.github/actions/install-llvm
 
       - name: Build full workspace (release)
-        run: cargo build --release --workspace
+        run: |
+          INCLUDE_OPTIONAL='${{ github.event.inputs.include_optional }}'
+          if [[ "$INCLUDE_OPTIONAL" == "true" ]]; then
+            cargo build --release --workspace
+          else
+            cargo build --release --workspace --exclude openvm --exclude jolt --exclude sp1
+          fi
 
       - name: Build nexus and cairo-m separately
         run: |
@@ -235,6 +260,12 @@ jobs:
 
       - name: Run benches in ${{ matrix.crate }}
         run: |
+          PROFILE="full"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            PROFILE="reduced"
+          fi
+          export BENCH_INPUT_PROFILE="$PROFILE"
+          echo "Using BENCH_INPUT_PROFILE=$BENCH_INPUT_PROFILE for ${{ matrix.crate }}"
           cd ${{ matrix.crate }}
           cargo bench
 

--- a/.github/workflows/sh_benchmarks_parallel.yml
+++ b/.github/workflows/sh_benchmarks_parallel.yml
@@ -155,6 +155,12 @@ jobs:
       - name: Run benches in ${{ matrix.folder }}
         run: |
           set -euo pipefail
+          PROFILE="full"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            PROFILE="reduced"
+          fi
+          export BENCH_INPUT_PROFILE="$PROFILE"
+          echo "Using BENCH_INPUT_PROFILE=$BENCH_INPUT_PROFILE for ${{ matrix.folder }}"
           if [[ -f ./benchmark.sh ]]; then
             bash ./benchmark.sh --system-dir "./${{ matrix.folder }}"
           else

--- a/jolt/benches/sha256.rs
+++ b/jolt/benches/sha256.rs
@@ -5,7 +5,6 @@ use jolt::{
 use std::collections::HashMap;
 use utils::{
     harness::ProvingSystem,
-    metadata::SHA2_INPUTS,
     zkvm::{SHA256_BENCH, helpers::load_or_compile_program},
 };
 
@@ -16,7 +15,7 @@ utils::define_benchmark_harness!(
     "sha256_mem_jolt",
     {
         let mut programs = HashMap::new();
-        for input_size in SHA2_INPUTS {
+        for input_size in utils::metadata::selected_sha2_inputs() {
             programs.insert(
                 input_size,
                 load_or_compile_program(

--- a/polyhedra-expander/build.rs
+++ b/polyhedra-expander/build.rs
@@ -16,9 +16,9 @@ fn main() {
     let utils_metadata = workspace_root.join("polyhedra-expander/src/metadata.rs");
     let contents = fs::read_to_string(&utils_metadata).expect("read src/metadata.rs");
 
-    // Parse pub const SHA2_INPUTS: [usize; N] = [a, b, c];
+    // Always parse the full set of input sizes from const SHA2_INPUTS_FULL: [usize; N] = [a, b, c];
     let mut sizes: Vec<String> = Vec::new();
-    if let Some(id_start) = contents.find("SHA2_INPUTS") {
+    if let Some(id_start) = contents.find("SHA2_INPUTS_FULL") {
         let after_id = &contents[id_start..];
         if let Some(eq_rel) = after_id.find('=') {
             let after_eq = &after_id[eq_rel + 1..];
@@ -96,6 +96,7 @@ fn main() {
     let out_file = out_dir.join("sha256_sizes.rs");
     fs::write(&out_file, final_out).expect("write generated sha256_sizes.rs");
 
+    println!("cargo:rerun-if-env-changed=BENCH_INPUT_PROFILE");
     println!("cargo:rerun-if-changed={}", template_path.display());
     println!("cargo:rerun-if-changed={}", utils_metadata.display());
 }

--- a/utils/src/harness.rs
+++ b/utils/src/harness.rs
@@ -1,5 +1,5 @@
 use crate::bench::{Metrics, compile_binary, run_measure_mem_script, write_json_metrics};
-use crate::metadata::SHA2_INPUTS;
+use crate::metadata::selected_sha2_inputs;
 use criterion::{BatchSize, Criterion};
 
 const SAMPLE_SIZE: usize = 10;
@@ -111,9 +111,9 @@ fn mem_report_filename(target: &str, size: usize, system: &str, feat: Option<&st
 
 fn input_sizes_for(target: BenchTarget, _fixed: Option<usize>) -> Vec<usize> {
     match target {
-        BenchTarget::Sha256 => SHA2_INPUTS.to_vec(),
+        BenchTarget::Sha256 => selected_sha2_inputs(),
         BenchTarget::Ecdsa => vec![32],
-        BenchTarget::Keccak => SHA2_INPUTS.to_vec(),
+        BenchTarget::Keccak => selected_sha2_inputs(),
     }
 }
 

--- a/utils/src/main.rs
+++ b/utils/src/main.rs
@@ -50,19 +50,19 @@ fn main() {
         Command::Sizes {
             command: SizesCommand::List,
         } => {
-            let json =
-                serde_json::to_string(&utils::metadata::SHA2_INPUTS).expect("serialize sizes");
+            let json = serde_json::to_string(&utils::metadata::selected_sha2_inputs())
+                .expect("serialize sizes");
             println!("{}", json);
         }
         Command::Sizes {
             command: SizesCommand::Len,
         } => {
-            println!("{}", utils::metadata::SHA2_INPUTS.len());
+            println!("{}", utils::metadata::selected_sha2_inputs().len());
         }
         Command::Sizes {
             command: SizesCommand::Get { index },
         } => {
-            let sizes = &utils::metadata::SHA2_INPUTS;
+            let sizes = &utils::metadata::selected_sha2_inputs();
             if let Some(size) = sizes.get(index) {
                 println!("{}", size);
             } else {

--- a/utils/src/metadata.rs
+++ b/utils/src/metadata.rs
@@ -1,1 +1,9 @@
-pub const SHA2_INPUTS: [usize; 2] = [128, 256];
+const SHA2_INPUTS_REDUCED: [usize; 2] = [128, 256];
+const SHA2_INPUTS_FULL: [usize; 5] = [128, 256, 512, 1024, 2048];
+
+pub fn selected_sha2_inputs() -> Vec<usize> {
+    match std::env::var("BENCH_INPUT_PROFILE").ok().as_deref() {
+        Some("reduced") => SHA2_INPUTS_REDUCED.to_vec(),
+        _ => SHA2_INPUTS_FULL.to_vec(),
+    }
+}


### PR DESCRIPTION
- SP1, OpenVM and Jolt benchmarks don't run by default - only on manual dispatch if the input is set;
- Benchmarks _on PR_ run with the "reduced" input set, e.g. 128B and 256B for SHA-256 (same as current);
- Benchmarks _on PR merge to CSP-Q3-2025 branch_ run with the full input set of 128 - 2048B