### PR TITLE
Report additional properties of proving systems and circuits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,6 +2693,7 @@ name = "circom"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ark-bn254",
  "circom-prover",
  "clap",
  "criterion",

--- a/binius64/benches/sha256_bench.rs
+++ b/binius64/benches/sha256_bench.rs
@@ -9,6 +9,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::Binius64,
     None,
     "sha256_mem_binius64",
+    utils::harness::BenchProperties::default(),
     |input_size| {
         prepare(input_size).expect("Failed to prepare sha256 circuit for prove/verify")
     },

--- a/binius64/benches/sha256_bench.rs
+++ b/binius64/benches/sha256_bench.rs
@@ -49,5 +49,6 @@ utils::define_benchmark_harness!(
             .expect("Failed to serialize constraint system into byte array");
         buf.len()
     },
-    |(proof, _pub_witness)| proof.len()
+    |(proof, _pub_witness)| proof.len(),
+    |(_, _, cs, _, _, _)| cs.n_and_constraints() + cs.n_mul_constraints()
 );

--- a/binius64/benches/sha256_bench.rs
+++ b/binius64/benches/sha256_bench.rs
@@ -25,6 +25,7 @@ utils::define_benchmark_harness!(
     |input_size| {
         prepare(input_size).expect("Failed to prepare sha256 circuit for prove/verify")
     },
+    |(_, _, cs, _, _, _)| { cs.n_and_constraints() + cs.n_mul_constraints() },
     |(_verifier, prover, _cs, sha256_circuit, compiled_circuit, input_size)| {
         binius64::prove::<StdDigest, StdCompression, ParallelCompressionAdaptor<StdCompression>>(
             prover,
@@ -49,6 +50,5 @@ utils::define_benchmark_harness!(
             .expect("Failed to serialize constraint system into byte array");
         buf.len()
     },
-    |(proof, _pub_witness)| proof.len(),
-    |(_, _, cs, _, _, _)| cs.n_and_constraints() + cs.n_mul_constraints()
+    |(proof, _pub_witness)| proof.len()
 );

--- a/binius64/benches/sha256_bench.rs
+++ b/binius64/benches/sha256_bench.rs
@@ -2,14 +2,26 @@ use binius_prover::hash::parallel_compression::ParallelCompressionAdaptor;
 use binius_utils::serialization::SerializeBytes;
 use binius_verifier::hash::{StdCompression, StdDigest};
 use binius64::prepare;
-use utils::harness::ProvingSystem;
+use utils::harness::{AuditStatus, BenchProperties, ProvingSystem};
 
 utils::define_benchmark_harness!(
     BenchTarget::Sha256,
     ProvingSystem::Binius64,
     None,
     "sha256_mem_binius64",
-    utils::harness::BenchProperties::default(),
+    BenchProperties {
+        proving_system: Some("Binius64".to_string()),
+        field_curve: Some("GHASH binary field".to_string()), // https://www.binius.xyz/basics/binius64-vs-v0
+        iop: Some("Binius64".to_string()),
+        pcs: Some("Binius64".to_string()),
+        arithm: Some("Binius64".to_string()),
+        is_zk: Some(true),       // https://www.binius.xyz/basics/binius64-vs-v0
+        security_bits: Some(96), // https://github.com/IrreducibleOSS/binius64/blob/main/verifier/verifier/src/verify.rs#L40
+        is_pq: Some(true),       // hash-based PCS
+        is_maintained: Some(true),
+        is_audited: Some(AuditStatus::NotAudited),
+        isa: None,
+    },
     |input_size| {
         prepare(input_size).expect("Failed to prepare sha256 circuit for prove/verify")
     },

--- a/cairo-m/benches/sha256_bench.rs
+++ b/cairo-m/benches/sha256_bench.rs
@@ -6,6 +6,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::CairoM,
     None,
     "sha256_mem_cairo_m",
+    utils::harness::BenchProperties::default(),
     |input_size| { prepare(input_size) },
     |(program, (entrypoint_name, runner_inputs))| {
         prove(program, (entrypoint_name, runner_inputs))

--- a/cairo-m/benches/sha256_bench.rs
+++ b/cairo-m/benches/sha256_bench.rs
@@ -1,4 +1,7 @@
 use cairo_m::{prepare, prove, verify};
+use cairo_m_common::{InputValue, Program};
+use cairo_m_prover::{adapter::import_from_runner_output, public_data::PublicData};
+use cairo_m_runner::run_cairo_program;
 use utils::harness::ProvingSystem;
 
 utils::define_benchmark_harness!(
@@ -8,10 +11,36 @@ utils::define_benchmark_harness!(
     "sha256_mem_cairo_m",
     utils::harness::BenchProperties::default(),
     |input_size| { prepare(input_size) },
+    |_| 0,
     |(program, (entrypoint_name, runner_inputs))| {
         prove(program, (entrypoint_name, runner_inputs))
     },
     |_, proof| { verify(proof) },
     |(compiled_program, _)| { compiled_program.len() },
-    |proof| proof.stark_proof.size_estimate()
+    |proof| proof.stark_proof.size_estimate(),
+    |(program, (entrypoint_name, runner_inputs)): &(Program, (String, Vec<InputValue>))| {
+        // Run/Execute the program
+        let runner_output = run_cairo_program(
+            program,
+            entrypoint_name.as_str(),
+            runner_inputs.as_slice(),
+            Default::default(),
+        )
+        .expect("failed to run cairo program");
+
+        // Proof Generation
+        let segment = runner_output
+            .vm
+            .segments
+            .clone()
+            .into_iter()
+            .next()
+            .unwrap();
+
+        let prover_input =
+            import_from_runner_output(segment, runner_output.public_address_ranges.clone())
+                .expect("Failed to import runner output for proof generation");
+
+        PublicData::new(&prover_input).clock.0 as u64
+    }
 );

--- a/cairo-m/src/lib.rs
+++ b/cairo-m/src/lib.rs
@@ -99,9 +99,8 @@ pub fn prove(
 
     let pcs_config = REGULAR_96_BITS;
 
-    let proof = prove_cairo_m::<Blake2sMerkleChannel>(&mut prover_input, Some(pcs_config))
-        .expect("failed to generate proof");
-    proof
+    prove_cairo_m::<Blake2sMerkleChannel>(&mut prover_input, Some(pcs_config))
+        .expect("failed to generate proof")
 }
 
 pub fn verify(proof: &Proof<Blake2sMerkleHasher>) {

--- a/circom/Cargo.toml
+++ b/circom/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 serde_json = { workspace = true }
 utils = { workspace = true }
+ark-bn254 = "0.5.0"
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/circom/benches/sha256_bench.rs
+++ b/circom/benches/sha256_bench.rs
@@ -1,6 +1,6 @@
 use circom::prepare;
 use circom_prover::prover::CircomProof;
-use utils::harness::ProvingSystem;
+use utils::harness::{AuditStatus, ProvingSystem};
 
 utils::define_benchmark_harness!(
     BenchTarget::Sha256,
@@ -37,7 +37,8 @@ utils::define_benchmark_harness!(
         serde_json::to_vec(proof)
             .expect("Failed to serialize proof")
             .len()
-    }
+    },
+    |(_witness_fn, _input_str, _zkey_path)| { 0 } // TODO: implement constraints size computation
 );
 
 fn sum_file_sizes_in_the_dir(file_path: &str) -> std::io::Result<usize> {

--- a/circom/benches/sha256_bench.rs
+++ b/circom/benches/sha256_bench.rs
@@ -7,6 +7,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::Circom,
     None,
     "sha256_mem_circom",
+    utils::harness::BenchProperties::default(),
     |input_size| { prepare(input_size) },
     |(witness_fn, input_str, zkey_path)| {
         circom::prove(*witness_fn, input_str.clone(), zkey_path.clone())

--- a/circom/benches/sha256_bench.rs
+++ b/circom/benches/sha256_bench.rs
@@ -24,6 +24,13 @@ utils::define_benchmark_harness!(
         isa: None,
     },
     |input_size| { prepare(input_size) },
+    |(_witness_fn, _input_str, zkey_path)| {
+        let (_, constraint_matrices) = ark_circom::read_zkey::<_, Bn254>(&mut BufReader::new(
+            File::open(zkey_path).expect("Unable to open zkey"),
+        ))
+        .expect("Unable to read zkey");
+        constraint_matrices.num_constraints
+    },
     |(witness_fn, input_str, zkey_path)| {
         circom::prove(*witness_fn, input_str.clone(), zkey_path.clone())
     },
@@ -40,13 +47,6 @@ utils::define_benchmark_harness!(
         serde_json::to_vec(proof)
             .expect("Failed to serialize proof")
             .len()
-    },
-    |(_witness_fn, _input_str, zkey_path)| {
-        let (_, constraint_matrices) = ark_circom::read_zkey::<_, Bn254>(&mut BufReader::new(
-            File::open(zkey_path).expect("Unable to open zkey"),
-        ))
-        .expect("Unable to read zkey");
-        constraint_matrices.num_constraints
     }
 );
 

--- a/circom/benches/sha256_bench.rs
+++ b/circom/benches/sha256_bench.rs
@@ -7,7 +7,19 @@ utils::define_benchmark_harness!(
     ProvingSystem::Circom,
     None,
     "sha256_mem_circom",
-    utils::harness::BenchProperties::default(),
+    utils::harness::BenchProperties {
+        proving_system: Some("Groth16".to_string()),
+        field_curve: Some("Bn254".to_string()),
+        iop: Some("Groth16".to_string()),
+        pcs: None,
+        arithm: Some("R1CS".to_string()),
+        is_zk: Some(true),
+        security_bits: Some(128),
+        is_pq: Some(false),
+        is_maintained: Some(true),
+        is_audited: Some(AuditStatus::PartiallyAudited),
+        isa: None,
+    },
     |input_size| { prepare(input_size) },
     |(witness_fn, input_str, zkey_path)| {
         circom::prove(*witness_fn, input_str.clone(), zkey_path.clone())

--- a/jolt/benches/sha256.rs
+++ b/jolt/benches/sha256.rs
@@ -29,10 +29,10 @@ utils::define_benchmark_harness!(
         programs
     },
     prepare_sha256,
+    |_, _| 0,
     prove_sha256,
     verify_sha256,
     preprocessing_size,
     proof_size,
-    |_, _| 0,
     execution_cycles
 );

--- a/jolt/benches/sha256.rs
+++ b/jolt/benches/sha256.rs
@@ -14,6 +14,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::Jolt,
     None,
     "sha256_mem_jolt",
+    utils::harness::BenchProperties::default(),
     {
         let mut programs = HashMap::new();
         for input_size in SHA2_INPUTS {

--- a/jolt/benches/sha256.rs
+++ b/jolt/benches/sha256.rs
@@ -33,5 +33,6 @@ utils::define_benchmark_harness!(
     verify_sha256,
     preprocessing_size,
     proof_size,
+    |_, _| 0,
     execution_cycles
 );

--- a/miden/benches/sha256.rs
+++ b/miden/benches/sha256.rs
@@ -18,5 +18,6 @@ utils::define_benchmark_harness!(
     verify_sha256,
     preprocessing_size,
     proof_size,
+    |_, _| 0,
     execution_cycles
 );

--- a/miden/benches/sha256.rs
+++ b/miden/benches/sha256.rs
@@ -11,6 +11,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::Miden,
     None,
     "sha256_mem_miden",
+    utils::harness::BenchProperties::default(),
     { load_or_compile_program(&MidenAsm, SHA256_BENCH) },
     prepare_sha256,
     prove_sha256,

--- a/miden/benches/sha256.rs
+++ b/miden/benches/sha256.rs
@@ -14,10 +14,10 @@ utils::define_benchmark_harness!(
     utils::harness::BenchProperties::default(),
     { load_or_compile_program(&MidenAsm, SHA256_BENCH) },
     prepare_sha256,
+    |_, _| 0,
     prove_sha256,
     verify_sha256,
     preprocessing_size,
     proof_size,
-    |_, _| 0,
     execution_cycles
 );

--- a/nexus/benches/sha256.rs
+++ b/nexus/benches/sha256.rs
@@ -3,8 +3,8 @@ use nexus::{
     execution_cycles, prepare_sha256, preprocessing_size, proof_size, prove_sha256, verify_sha256,
 };
 use utils::harness::ProvingSystem;
-use utils::zkvm::SHA256_BENCH;
 use utils::zkvm::helpers::load_or_compile_program;
+use utils::zkvm::SHA256_BENCH;
 
 utils::define_benchmark_harness!(
     BenchTarget::Sha256,
@@ -14,6 +14,7 @@ utils::define_benchmark_harness!(
     utils::harness::BenchProperties::default(),
     { load_or_compile_program(&RustRv32i, SHA256_BENCH) },
     prepare_sha256,
+    |_, _| 0,
     prove_sha256,
     verify_sha256,
     preprocessing_size,

--- a/nexus/benches/sha256.rs
+++ b/nexus/benches/sha256.rs
@@ -11,6 +11,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::Nexus,
     None,
     "sha256_mem_nexus",
+    utils::harness::BenchProperties::default(),
     { load_or_compile_program(&RustRv32i, SHA256_BENCH) },
     prepare_sha256,
     prove_sha256,

--- a/openvm/benches/sha256.rs
+++ b/openvm/benches/sha256.rs
@@ -18,5 +18,6 @@ utils::define_benchmark_harness!(
     verify_sha256,
     preprocessing_size,
     proof_size,
+    |_, _| 0,
     execution_cycles
 );

--- a/openvm/benches/sha256.rs
+++ b/openvm/benches/sha256.rs
@@ -11,6 +11,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::OpenVM,
     None,
     "sha256_mem_openvm",
+    utils::harness::BenchProperties::default(),
     { load_or_compile_program(&RustRv32imaCustomized, SHA256_BENCH) },
     prepare_sha256,
     prove_sha256,

--- a/openvm/benches/sha256.rs
+++ b/openvm/benches/sha256.rs
@@ -14,10 +14,10 @@ utils::define_benchmark_harness!(
     utils::harness::BenchProperties::default(),
     { load_or_compile_program(&RustRv32imaCustomized, SHA256_BENCH) },
     prepare_sha256,
+    |_, _| 0,
     prove_sha256,
     verify_sha256,
     preprocessing_size,
     proof_size,
-    |_, _| 0,
     execution_cycles
 );

--- a/plonky2/benches/prove_verify.rs
+++ b/plonky2/benches/prove_verify.rs
@@ -38,5 +38,6 @@ utils::define_benchmark_harness!(
         let mut buffer = Vec::new();
         buffer.write_proof(&proof.proof).unwrap();
         buffer.len()
-    }
+    },
+    |(circuit_data, _)| { circuit_data.common.num_gate_constraints }
 );

--- a/plonky2/benches/prove_verify.rs
+++ b/plonky2/benches/prove_verify.rs
@@ -14,6 +14,7 @@ utils::define_benchmark_harness!(
     "sha256_no_lookup_mem",
     utils::harness::BenchProperties::default(),
     sha256_prepare,
+    |(circuit_data, _)| { circuit_data.common.num_gate_constraints },
     |(circuit_data, pw)| { prove(circuit_data, pw.clone()) },
     |(circuit_data, _pw), proof| {
         let verifier_data = circuit_data.verifier_data();
@@ -38,6 +39,5 @@ utils::define_benchmark_harness!(
         let mut buffer = Vec::new();
         buffer.write_proof(&proof.proof).unwrap();
         buffer.len()
-    },
-    |(circuit_data, _)| { circuit_data.common.num_gate_constraints }
+    }
 );

--- a/plonky2/benches/prove_verify.rs
+++ b/plonky2/benches/prove_verify.rs
@@ -12,6 +12,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::Plonky2,
     None,
     "sha256_no_lookup_mem",
+    utils::harness::BenchProperties::default(),
     sha256_prepare,
     |(circuit_data, pw)| { prove(circuit_data, pw.clone()) },
     |(circuit_data, _pw), proof| {

--- a/polyhedra-expander/benches/prove_verify.rs
+++ b/polyhedra-expander/benches/prove_verify.rs
@@ -9,6 +9,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::Expander,
     None,
     "sha256_mem_expander",
+    utils::harness::BenchProperties::default(),
     {
         let universe = MPIConfig::init().expect("Failed to initialize MPI");
         let world = universe.world();

--- a/polyhedra-expander/benches/prove_verify.rs
+++ b/polyhedra-expander/benches/prove_verify.rs
@@ -17,6 +17,11 @@ utils::define_benchmark_harness!(
         (universe, world)
     },
     |size, _| prepare(size),
+    |(circuit_bytes, witness_bytes), (universe, world)| get_constraints(
+        circuit_bytes,
+        witness_bytes,
+        MPIConfig::prover_new(Some(universe), Some(world))
+    ),
     |(circuit_bytes, witness_bytes), (universe, world)| {
         let (_, proof) = prove(
             circuit_bytes,
@@ -40,10 +45,5 @@ utils::define_benchmark_harness!(
         );
     },
     |(circuit_bytes, _), _| { circuit_bytes.len() },
-    |proof, _shared| proof.bytes.len(),
-    |(circuit_bytes, witness_bytes), (universe, world)| get_constraints(
-        circuit_bytes,
-        witness_bytes,
-        MPIConfig::prover_new(Some(universe), Some(world))
-    )
+    |proof, _shared| proof.bytes.len()
 );

--- a/polyhedra-expander/benches/prove_verify.rs
+++ b/polyhedra-expander/benches/prove_verify.rs
@@ -1,4 +1,5 @@
 use gkr_engine::MPIConfig;
+use sha256_expander_benchmark::bench::get_constraints;
 use sha256_expander_benchmark::bench::prepare;
 use sha256_expander_benchmark::bench::prove;
 use sha256_expander_benchmark::bench::verify;
@@ -39,5 +40,10 @@ utils::define_benchmark_harness!(
         );
     },
     |(circuit_bytes, _), _| { circuit_bytes.len() },
-    |proof, _shared| proof.bytes.len()
+    |proof, _shared| proof.bytes.len(),
+    |(circuit_bytes, witness_bytes), (universe, world)| get_constraints(
+        circuit_bytes,
+        witness_bytes,
+        MPIConfig::prover_new(Some(universe), Some(world))
+    )
 );

--- a/provekit/benches/prove_verify.rs
+++ b/provekit/benches/prove_verify.rs
@@ -13,5 +13,6 @@ utils::define_benchmark_harness!(
         verify(proof, proof_scheme).unwrap();
     },
     |(_, _, circuit_path)| { preprocessing_size(circuit_path) },
-    |proof| { proof.whir_r1cs_proof.transcript.len() }
+    |proof| { proof.whir_r1cs_proof.transcript.len() },
+    |(proof_scheme, _, _)| { proof_scheme.r1cs.num_constraints() }
 );

--- a/provekit/benches/prove_verify.rs
+++ b/provekit/benches/prove_verify.rs
@@ -8,11 +8,11 @@ utils::define_benchmark_harness!(
     "sha256_mem_provekit",
     utils::harness::BenchProperties::default(),
     prepare_sha256,
+    |(proof_scheme, _, _)| { proof_scheme.r1cs.num_constraints() },
     |(proof_scheme, toml_path, _)| { prove(proof_scheme, toml_path) },
     |(proof_scheme, _, _), proof| {
         verify(proof, proof_scheme).unwrap();
     },
     |(_, _, circuit_path)| { preprocessing_size(circuit_path) },
-    |proof| { proof.whir_r1cs_proof.transcript.len() },
-    |(proof_scheme, _, _)| { proof_scheme.r1cs.num_constraints() }
+    |proof| { proof.whir_r1cs_proof.transcript.len() }
 );

--- a/provekit/benches/prove_verify.rs
+++ b/provekit/benches/prove_verify.rs
@@ -6,6 +6,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::Provekit,
     None,
     "sha256_mem_provekit",
+    utils::harness::BenchProperties::default(),
     prepare_sha256,
     |(proof_scheme, toml_path, _)| { prove(proof_scheme, toml_path) },
     |(proof_scheme, _, _), proof| {

--- a/risc0/benches/sha256.rs
+++ b/risc0/benches/sha256.rs
@@ -18,5 +18,6 @@ utils::define_benchmark_harness!(
     verify_sha256,
     preprocessing_size,
     proof_size,
+    |_, _| 0,
     execution_cycles
 );

--- a/risc0/benches/sha256.rs
+++ b/risc0/benches/sha256.rs
@@ -14,10 +14,10 @@ utils::define_benchmark_harness!(
     utils::harness::BenchProperties::default(),
     { load_or_compile_program(&RustRv32imaCustomized, SHA256_BENCH) },
     prepare_sha256,
+    |_, _| 0,
     prove_sha256,
     verify_sha256,
     preprocessing_size,
     proof_size,
-    |_, _| 0,
     execution_cycles
 );

--- a/risc0/benches/sha256.rs
+++ b/risc0/benches/sha256.rs
@@ -11,6 +11,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::Risc0,
     None,
     "sha256_mem_risc0",
+    utils::harness::BenchProperties::default(),
     { load_or_compile_program(&RustRv32imaCustomized, SHA256_BENCH) },
     prepare_sha256,
     prove_sha256,

--- a/sp1/benches/sha256.rs
+++ b/sp1/benches/sha256.rs
@@ -18,5 +18,6 @@ utils::define_benchmark_harness!(
     verify_sha256,
     preprocessing_size,
     proof_size,
+    |_, _| 0,
     execution_cycles
 );

--- a/sp1/benches/sha256.rs
+++ b/sp1/benches/sha256.rs
@@ -11,6 +11,7 @@ utils::define_benchmark_harness!(
     ProvingSystem::Sp1,
     None,
     "sha256_mem_sp1",
+    utils::harness::BenchProperties::default(),
     { load_or_compile_program(&RustRv32imaCustomized, SHA256_BENCH) },
     prepare_sha256,
     prove_sha256,

--- a/sp1/benches/sha256.rs
+++ b/sp1/benches/sha256.rs
@@ -14,10 +14,10 @@ utils::define_benchmark_harness!(
     utils::harness::BenchProperties::default(),
     { load_or_compile_program(&RustRv32imaCustomized, SHA256_BENCH) },
     prepare_sha256,
+    |_, _| 0,
     prove_sha256,
     verify_sha256,
     preprocessing_size,
     proof_size,
-    |_, _| 0,
     execution_cycles
 );

--- a/utils/src/bench.rs
+++ b/utils/src/bench.rs
@@ -102,6 +102,20 @@ fn display_duration(duration: &Duration) -> String {
     duration.human_duration().to_string()
 }
 
+fn display_string(s: &Option<String>) -> String {
+    match s {
+        Some(v) if !v.is_empty() => v.clone(),
+        _ => "-".to_string(),
+    }
+}
+
+fn display_cycles(cycles: &Option<u64>) -> String {
+    match cycles {
+        Some(v) => v.human_count_bare().to_string(),
+        None => "-".to_string(),
+    }
+}
+
 impl Metrics {
     pub fn new(
         name: String,
@@ -126,20 +140,6 @@ impl Metrics {
             peak_memory: 0,
             bench_properties,
         }
-    }
-}
-
-fn display_string(s: &Option<String>) -> String {
-    match s {
-        Some(v) if !v.is_empty() => v.clone(),
-        _ => "-".to_string(),
-    }
-}
-
-fn display_cycles(cycles: &Option<u64>) -> String {
-    match cycles {
-        Some(v) => v.human_count_bare().to_string(),
-        None => "-".to_string(),
     }
 }
 

--- a/utils/src/bench.rs
+++ b/utils/src/bench.rs
@@ -86,6 +86,7 @@ pub struct Metrics {
     pub proof_size: usize,
     #[tabled(display_with = "display_bytes")]
     pub preprocessing_size: usize,
+    pub num_constraints: usize,
     #[tabled(display_with = "display_bytes")]
     pub peak_memory: usize,
     #[serde(flatten)]
@@ -121,6 +122,7 @@ impl Metrics {
             cycles: None,
             proof_size: 0,
             preprocessing_size: 0,
+            num_constraints: 0,
             peak_memory: 0,
             bench_properties,
         }

--- a/utils/src/bin/collect_benchmarks.rs
+++ b/utils/src/bin/collect_benchmarks.rs
@@ -68,17 +68,16 @@ fn extract_metrics(dir: &Path, metrics_file_path: &Path) -> io::Result<(Metrics,
     let target = &metrics.target;
     let input_size = metrics.input_size;
     let proving_system = &metrics.name;
-    let feat = &metrics.feat;
+    let feat = metrics.feat.as_deref();
 
     if metrics.proof_duration.is_zero() {
-        let crit_path_p = if feat.is_empty() {
-            dir.parent().unwrap().join(format!(
+        let crit_path_p = match feat {
+            Some(f) if !f.is_empty() => dir.parent().unwrap().join(format!(
+                "target/criterion/{target}_{input_size}_{proving_system}_{f}/{target}_{input_size}_{proving_system}_{f}_prove/new/estimates.json"
+            )),
+            _ => dir.parent().unwrap().join(format!(
                 "target/criterion/{target}_{input_size}_{proving_system}/{target}_{input_size}_{proving_system}_prove/new/estimates.json"
-            ))
-        } else {
-            dir.parent().unwrap().join(format!(
-                "target/criterion/{target}_{input_size}_{proving_system}_{feat}/{target}_{input_size}_{proving_system}_{feat}_prove/new/estimates.json"
-            ))
+            )),
         };
         if crit_path_p.exists() {
             println!("Reading proof duration from {}", crit_path_p.display());
@@ -120,14 +119,13 @@ fn extract_metrics(dir: &Path, metrics_file_path: &Path) -> io::Result<(Metrics,
     }
 
     if metrics.verify_duration.is_zero() {
-        let crit_path_v = if feat.is_empty() {
-            dir.parent().unwrap().join(format!(
+        let crit_path_v = match feat {
+            Some(f) if !f.is_empty() => dir.parent().unwrap().join(format!(
+                "target/criterion/{target}_{input_size}_{proving_system}_{f}/{target}_{input_size}_{proving_system}_{f}_verify/new/estimates.json"
+            )),
+            _ => dir.parent().unwrap().join(format!(
                 "target/criterion/{target}_{input_size}_{proving_system}/{target}_{input_size}_{proving_system}_verify/new/estimates.json"
-            ))
-        } else {
-            dir.parent().unwrap().join(format!(
-                "target/criterion/{target}_{input_size}_{proving_system}_{feat}/{target}_{input_size}_{proving_system}_{feat}_verify/new/estimates.json"
-            ))
+            )),
         };
         if crit_path_v.exists() {
             println!("Reading verify duration from {}", crit_path_v.display());
@@ -170,14 +168,13 @@ fn extract_metrics(dir: &Path, metrics_file_path: &Path) -> io::Result<(Metrics,
     }
 
     if metrics.peak_memory == 0 {
-        let mem_path = if feat.is_empty() {
-            dir.join(format!(
+        let mem_path = match feat {
+            Some(f) if !f.is_empty() => dir.join(format!(
+                "{target}_{input_size}_{proving_system}_{f}_mem_report.json"
+            )),
+            _ => dir.join(format!(
                 "{target}_{input_size}_{proving_system}_mem_report.json"
-            ))
-        } else {
-            dir.join(format!(
-                "{target}_{input_size}_{proving_system}_{feat}_mem_report.json"
-            ))
+            )),
         };
         if mem_path.exists() {
             println!("Reading peak memory from {}", mem_path.display());

--- a/utils/src/bin/format_hyperfine.rs
+++ b/utils/src/bin/format_hyperfine.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use utils::bench::Metrics;
+use utils::harness::BenchProperties;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Format hyperfine + RAM outputs into Metrics JSON and clean up", long_about = None)]
@@ -98,9 +99,10 @@ fn main() -> std::io::Result<()> {
         let mut metrics = Metrics::new(
             proving_system.clone(),
             feat,
-            Some(cli.is_zkvm),
+            cli.is_zkvm,
             target.clone(),
             input_size,
+            BenchProperties::default(),
         );
         metrics.proof_duration = to_duration_ns(prover_mean_sec);
         metrics.verify_duration = to_duration_ns(verifier_mean_sec);

--- a/utils/src/bin/format_hyperfine.rs
+++ b/utils/src/bin/format_hyperfine.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::time::Duration;
 use utils::bench::Metrics;
 use utils::harness::{AuditStatus, BenchProperties};

--- a/utils/src/bin/format_hyperfine.rs
+++ b/utils/src/bin/format_hyperfine.rs
@@ -19,6 +19,10 @@ struct Cli {
     #[arg(long)]
     name: Option<String>,
 
+    /// Optional feature name (default empty)
+    #[arg(long, default_value = "")]
+    feature: Option<String>,
+
     /// Mark as zkVM system (default: false)
     #[arg(long, default_value_t = false)]
     is_zkvm: bool,
@@ -86,10 +90,15 @@ fn main() -> std::io::Result<()> {
         let verifier_mean_sec = read_hyperfine_mean_seconds(&verifier_path)?;
         println!("Reading verifier time from {}", verifier_path.display());
 
+        let feat = match cli.feature.as_deref() {
+            Some(f) if !f.is_empty() => Some(f.to_string()),
+            _ => None,
+        };
+
         let mut metrics = Metrics::new(
             proving_system.clone(),
-            String::new(),
-            cli.is_zkvm,
+            feat,
+            Some(cli.is_zkvm),
             target.clone(),
             input_size,
         );

--- a/utils/src/bin/format_hyperfine.rs
+++ b/utils/src/bin/format_hyperfine.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use utils::bench::Metrics;
-use utils::harness::BenchProperties;
+use utils::harness::{AuditStatus, BenchProperties};
 
 #[derive(clap::Args, Debug, Clone, Default)]
 struct BenchPropsArgs {
@@ -30,11 +30,7 @@ struct BenchPropsArgs {
     #[arg(long)]
     is_zk: Option<bool>,
     #[arg(long)]
-    is_audited: Option<bool>,
-    #[arg(long)]
-    n_constraints: Option<u64>,
-    #[arg(long)]
-    cycles: Option<u64>,
+    is_audited: Option<String>,
     #[arg(long)]
     isa: Option<String>,
 }
@@ -51,9 +47,7 @@ impl From<BenchPropsArgs> for BenchProperties {
             is_pq: a.is_pq,
             is_maintained: a.is_maintained,
             is_zk: a.is_zk,
-            is_audited: a.is_audited,
-            n_constraints: a.n_constraints,
-            cycles: a.cycles,
+            is_audited: a.is_audited.map(|s| AuditStatus::from_str(&s).unwrap()),
             isa: a.isa,
         }
     }
@@ -225,8 +219,6 @@ fn merge_props(mut base: BenchProperties, override_: BenchProperties) -> BenchPr
     take!(is_maintained);
     take!(is_zk);
     take!(is_audited);
-    take!(n_constraints);
-    take!(cycles);
     take!(isa);
     base
 }

--- a/utils/src/bin/format_hyperfine.rs
+++ b/utils/src/bin/format_hyperfine.rs
@@ -9,6 +9,56 @@ use std::time::Duration;
 use utils::bench::Metrics;
 use utils::harness::BenchProperties;
 
+#[derive(clap::Args, Debug, Clone, Default)]
+struct BenchPropsArgs {
+    #[arg(long)]
+    proving_system: Option<String>,
+    #[arg(long)]
+    field_curve: Option<String>,
+    #[arg(long)]
+    iop: Option<String>,
+    #[arg(long)]
+    pcs: Option<String>,
+    #[arg(long)]
+    arithm: Option<String>,
+    #[arg(long)]
+    security_bits: Option<u64>,
+    #[arg(long)]
+    is_pq: Option<bool>,
+    #[arg(long)]
+    is_maintained: Option<bool>,
+    #[arg(long)]
+    is_zk: Option<bool>,
+    #[arg(long)]
+    is_audited: Option<bool>,
+    #[arg(long)]
+    n_constraints: Option<u64>,
+    #[arg(long)]
+    cycles: Option<u64>,
+    #[arg(long)]
+    isa: Option<String>,
+}
+
+impl From<BenchPropsArgs> for BenchProperties {
+    fn from(a: BenchPropsArgs) -> Self {
+        BenchProperties {
+            proving_system: a.proving_system,
+            field_curve: a.field_curve,
+            iop: a.iop,
+            pcs: a.pcs,
+            arithm: a.arithm,
+            security_bits: a.security_bits,
+            is_pq: a.is_pq,
+            is_maintained: a.is_maintained,
+            is_zk: a.is_zk,
+            is_audited: a.is_audited,
+            n_constraints: a.n_constraints,
+            cycles: a.cycles,
+            isa: a.isa,
+        }
+    }
+}
+
 #[derive(Parser, Debug)]
 #[command(author, version, about = "Format hyperfine + RAM outputs into Metrics JSON and clean up", long_about = None)]
 struct Cli {
@@ -27,6 +77,14 @@ struct Cli {
     /// Mark as zkVM system (default: false)
     #[arg(long, default_value_t = false)]
     is_zkvm: bool,
+
+    /// Optional path to properties file (JSON) to populate BenchProperties
+    #[arg(long)]
+    properties: Option<PathBuf>,
+
+    /// CLI overrides for BenchProperties (fields not provided remain unchanged)
+    #[command(flatten)]
+    props: BenchPropsArgs,
 }
 
 #[derive(Deserialize)]
@@ -96,13 +154,20 @@ fn main() -> std::io::Result<()> {
             _ => None,
         };
 
+        let file_props = match &cli.properties {
+            Some(p) => load_properties_json(p)?,
+            None => BenchProperties::default(),
+        };
+        let override_props: BenchProperties = cli.props.clone().into();
+        let bench_properties = merge_props(file_props, override_props);
+
         let mut metrics = Metrics::new(
             proving_system.clone(),
             feat,
             cli.is_zkvm,
             target.clone(),
             input_size,
-            BenchProperties::default(),
+            bench_properties,
         );
         metrics.proof_duration = to_duration_ns(prover_mean_sec);
         metrics.verify_duration = to_duration_ns(verifier_mean_sec);
@@ -135,6 +200,35 @@ fn main() -> std::io::Result<()> {
     }
 
     Ok(())
+}
+
+fn load_properties_json(path: &Path) -> std::io::Result<BenchProperties> {
+    let s = fs::read_to_string(path)?;
+    serde_json::from_str::<BenchProperties>(&s).map_err(|e| io_err(&e.to_string()))
+}
+
+fn merge_props(mut base: BenchProperties, override_: BenchProperties) -> BenchProperties {
+    macro_rules! take {
+        ($f:ident) => {
+            if override_.$f.is_some() {
+                base.$f = override_.$f;
+            }
+        };
+    }
+    take!(proving_system);
+    take!(field_curve);
+    take!(iop);
+    take!(pcs);
+    take!(arithm);
+    take!(security_bits);
+    take!(is_pq);
+    take!(is_maintained);
+    take!(is_zk);
+    take!(is_audited);
+    take!(n_constraints);
+    take!(cycles);
+    take!(isa);
+    base
 }
 
 fn read_hyperfine_mean_seconds(path: &Path) -> std::io::Result<f64> {

--- a/utils/src/harness.rs
+++ b/utils/src/harness.rs
@@ -388,7 +388,7 @@ fn measure_ram(
 macro_rules! __define_benchmark_harness {
     // With shared state
     ($public_group_ident:ident, $target:expr, $system:expr, $feature:expr, $mem_binary_name:expr, $properties:expr, { $($shared_init:tt)* },
-        $prepare:expr, $prove:expr, $verify:expr, $prep_size:expr, $proof_size:expr, $num_constraints:expr
+        $prepare:expr, $num_constraints:expr, $prove:expr, $verify:expr, $prep_size:expr, $proof_size:expr
     ) => {
         fn criterion_benchmarks(c: &mut ::criterion::Criterion) {
             let system = $system;
@@ -418,7 +418,7 @@ macro_rules! __define_benchmark_harness {
     };
     // No shared state, with execution_cycles
     ($public_group_ident:ident, $target:expr, $system:expr, $feature:expr, $mem_binary_name:expr, $properties:expr,
-        $prepare:expr, $prove:expr, $verify:expr, $prep_size:expr, $proof_size:expr, $num_constraints:expr, $execution_cycles:expr
+        $prepare:expr, $num_constraints:expr, $prove:expr, $verify:expr, $prep_size:expr, $proof_size:expr, $execution_cycles:expr
     ) => {
         fn criterion_benchmarks(c: &mut ::criterion::Criterion) {
             let system = $system;
@@ -447,7 +447,7 @@ macro_rules! __define_benchmark_harness {
     };
     // With shared state and execution_cycles
     ($public_group_ident:ident, $target:expr, $system:expr, $feature:expr, $mem_binary_name:expr, $properties:expr, { $($shared_init:tt)* },
-        $prepare:expr, $prove:expr, $verify:expr, $prep_size:expr, $proof_size:expr, $constraints_size:expr, $execution_cycles:expr
+        $prepare:expr, $num_constraints:expr, $prove:expr, $verify:expr, $prep_size:expr, $proof_size:expr, $execution_cycles:expr
     ) => {
         fn criterion_benchmarks(c: &mut ::criterion::Criterion) {
             let system = $system;
@@ -464,7 +464,7 @@ macro_rules! __define_benchmark_harness {
                 $properties,
                 &{ $($shared_init)* },
                 $prepare,
-                $constraints_size,
+                $num_constraints,
                 $prove,
                 $verify,
                 $prep_size,
@@ -477,7 +477,7 @@ macro_rules! __define_benchmark_harness {
     };
     // No shared state, no execution_cycles
     ($public_group_ident:ident, $target:expr, $system:expr, $feature:expr, $mem_binary_name:expr, $properties:expr,
-        $prepare:expr, $prove:expr, $verify:expr, $prep_size:expr, $proof_size:expr, $num_constraints:expr
+        $prepare:expr, $num_constraints:expr, $prove:expr, $verify:expr, $prep_size:expr, $proof_size:expr
     ) => {
         fn criterion_benchmarks(c: &mut ::criterion::Criterion) {
             let system = $system;

--- a/utils/src/harness.rs
+++ b/utils/src/harness.rs
@@ -84,6 +84,7 @@ use serde_with::skip_serializing_none;
 
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BenchProperties {
     // Classification
     pub proving_system: Option<String>,

--- a/utils/src/harness.rs
+++ b/utils/src/harness.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use crate::bench::{Metrics, compile_binary, run_measure_mem_script, write_json_metrics};
 use crate::metadata::SHA2_INPUTS;
 use criterion::{BatchSize, Criterion};
@@ -92,13 +94,15 @@ pub enum AuditStatus {
     PartiallyAudited,
 }
 
-impl AuditStatus {
-    pub fn from_str(s: &str) -> Option<AuditStatus> {
+impl FromStr for AuditStatus {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<AuditStatus, String> {
         match s {
-            "audited" => Some(AuditStatus::Audited),
-            "not_audited" => Some(AuditStatus::NotAudited),
-            "partially_audited" => Some(AuditStatus::PartiallyAudited),
-            _ => None,
+            "audited" => Ok(AuditStatus::Audited),
+            "not_audited" => Ok(AuditStatus::NotAudited),
+            "partially_audited" => Ok(AuditStatus::PartiallyAudited),
+            _ => Err(format!("Invalid audit status: {}", s)),
         }
     }
 }

--- a/utils/src/harness.rs
+++ b/utils/src/harness.rs
@@ -82,6 +82,27 @@ pub struct BenchHarnessConfig<'a> {
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum AuditStatus {
+    #[serde(rename = "audited")]
+    Audited,
+    #[serde(rename = "not_audited")]
+    NotAudited,
+    #[serde(rename = "partially_audited")]
+    PartiallyAudited,
+}
+
+impl AuditStatus {
+    pub fn from_str(s: &str) -> Option<AuditStatus> {
+        match s {
+            "audited" => Some(AuditStatus::Audited),
+            "not_audited" => Some(AuditStatus::NotAudited),
+            "partially_audited" => Some(AuditStatus::PartiallyAudited),
+            _ => None,
+        }
+    }
+}
+
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -100,13 +121,9 @@ pub struct BenchProperties {
 
     // Maintenance / audit / zk
     pub is_maintained: Option<bool>,
-    pub is_audited: Option<bool>,
-
-    // Circuit characteristics
-    pub n_constraints: Option<u64>,
+    pub is_audited: Option<AuditStatus>,
 
     // zkVM specifics
-    pub cycles: Option<u64>,
     pub isa: Option<String>,
 }
 


### PR DESCRIPTION
- Report additional properties via the BenchProperties struct;
- For non Rust-systems they should be passed via JSON file;
- Only implemented the full BenchProperties for Binius64 and Circom, otherwise the PR would be too big;
- Let's add the remaining properties system-by-system (or at least in groups of 2-3); after we finish adding them, we make BenchProperties fields non-optional and remove the default constructor;
- Added a new closure for reporting the number of constraints;
- Optimistically left some zero stubs to report the # of constraints for zkVMs but this is TBD;
- Currently, Ere does not provide the underlying # of constraints;
- [bonus]: report Cairo-M execution cycles.