### PR TITLE
Fix CMake cache restoration 

### DIFF
--- a/.github/actions/install-ligero/action.yml
+++ b/.github/actions/install-ligero/action.yml
@@ -161,7 +161,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ inputs.ligero_path }}/build
-        key: native-build-${{ runner.os }}-Release-${{ hashFiles(format('{0}/CMakeLists.txt', inputs.ligero_path)) }}-${{ hashFiles(format('{0}/src/**', inputs.ligero_path)) }}
+        key: native-build-${{ runner.os }}-${{ contains(runner.labels, 'self-hosted') && 'selfhosted' || 'gh' }}-Release-${{ hashFiles(format('{0}/CMakeLists.txt', inputs.ligero_path)) }}-${{ hashFiles(format('{0}/src/**', inputs.ligero_path)) }}
 
     - name: Configure & build native
       shell: bash


### PR DESCRIPTION
Partition the CMake native build cache by runner type. When self-hosted runner restores CMake cache, it may restore wrong paths that were cached on the GitHub runner. Therefore, we need to distinguish caches by having separate keys for GH and self-hosted runners.