### PR TITLE
fix: bb preprocessing measurement

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   pull_request:
     branches:
-      - "CSP-Q3-2025"
+      - "main"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -7,10 +7,10 @@ concurrency:
 on:
   push:
     branches:
-      - "CSP-Q3-2025"
+      - "main"
   pull_request:
     branches:
-      - "CSP-Q3-2025"
+      - "main"
   workflow_dispatch:
     inputs:
       run_all:
@@ -55,7 +55,7 @@ jobs:
             REMOTE=upstream
           fi
 
-          BASE_BRANCH="CSP-Q3-2025"
+          BASE_BRANCH="main"
           git fetch --prune --no-tags --depth=1 "$REMOTE" "$BASE_BRANCH"
 
           # expose for later steps

--- a/.github/workflows/sh_benchmarks_parallel.yml
+++ b/.github/workflows/sh_benchmarks_parallel.yml
@@ -7,10 +7,10 @@ concurrency:
 on:
   push:
     branches:
-      - "CSP-Q3-2025"
+      - "main"
   pull_request:
     branches:
-      - "CSP-Q3-2025"
+      - "main"
   workflow_dispatch:
     inputs:
       run_all:
@@ -52,7 +52,7 @@ jobs:
             REMOTE=upstream
           fi
 
-          BASE_BRANCH="CSP-Q3-2025"
+          BASE_BRANCH="main"
           git fetch --prune --no-tags --depth=1 "$REMOTE" "$BASE_BRANCH"
 
           # expose for later steps

--- a/barretenberg/_measure_common.sh
+++ b/barretenberg/_measure_common.sh
@@ -59,8 +59,7 @@ bb_write_sizes_and_constraints() {
   json_output=$(jq -n \
     --argjson proof_size "$proof_size_bytes" \
     --argjson preprocessing_size "$preprocessing_size_bytes" \
-    --argjson crs_size "$CRS_SIZE_BYTES" \
-    '{proof_size: $proof_size, preprocessing_size: $preprocessing_size, crs_size: $crs_size}')
+    '{proof_size: $proof_size, preprocessing_size: $preprocessing_size}')
 
   echo "$json_output" > "$OUT_JSON_PATH"
   jq . "$OUT_JSON_PATH" || true

--- a/barretenberg/ecdsa_measure.sh
+++ b/barretenberg/ecdsa_measure.sh
@@ -11,9 +11,16 @@ OUT_JSON="${SIZES_JSON:-}"
 : "${STATE_JSON:?STATE_JSON is required}"
 : "${SIZES_JSON:?SIZES_JSON is required}"
 
+# Use shared common helper
+. "$SCRIPT_DIR/_measure_common.sh"
+
+# Clear CRS cache
+bb_clear_crs
+
 # Run one proving cycle to generate artifacts for measurement
 "$SCRIPT_DIR/ecdsa_prove.sh" >/dev/null 2>&1 || true
 
-# Use shared common helper to write sizes and update constraints
-. "$SCRIPT_DIR/_measure_common.sh"
-bb_write_sizes_and_constraints "ecdsa" "ecdsa.json" "$STATE_JSON" "$OUT_JSON" "$SCRIPT_DIR"
+# Measure CRS size after proving
+CRS_SIZE=$(bb_measure_crs_size)
+
+bb_write_sizes_and_constraints "ecdsa" "ecdsa.json" "$STATE_JSON" "$OUT_JSON" "$SCRIPT_DIR" "$CRS_SIZE"

--- a/barretenberg/sha256_measure.sh
+++ b/barretenberg/sha256_measure.sh
@@ -11,9 +11,16 @@ OUT_JSON="${SIZES_JSON:-}"
 : "${STATE_JSON:?STATE_JSON is required}"
 : "${SIZES_JSON:?SIZES_JSON is required}"
 
+# Use shared common helper
+. "$SCRIPT_DIR/_measure_common.sh"
+
+# Clear CRS cache
+bb_clear_crs
+
 # Run one proving cycle to generate artifacts for measurement
 "$SCRIPT_DIR/sha256_prove.sh" >/dev/null 2>&1 || true
 
-# Use shared common helper to write sizes and update constraints
-. "$SCRIPT_DIR/_measure_common.sh"
-bb_write_sizes_and_constraints "sha256" "sha256.json" "$STATE_JSON" "$OUT_JSON" "$SCRIPT_DIR"
+# Measure CRS size after proving
+CRS_SIZE=$(bb_measure_crs_size)
+
+bb_write_sizes_and_constraints "sha256" "sha256.json" "$STATE_JSON" "$OUT_JSON" "$SCRIPT_DIR" "$CRS_SIZE"

--- a/benchmark.sh
+++ b/benchmark.sh
@@ -88,6 +88,12 @@ for target in "${TARGETS[@]}"; do
     PROVER_JSON_FILE="$STATE_DIR/prover_${TARGET}_${INPUT_SIZE}.json"
     VERIFIER_JSON_FILE="$STATE_DIR/verifier_${TARGET}_${INPUT_SIZE}.json"
 
+    step "[$TARGET] Size measurement (size ${INPUT_SIZE})"
+    SIZES_JSON="$SYSTEM_DIR/${TARGET}_${INPUT_SIZE}_sizes.json"
+    SIZES_JSON="$SIZES_JSON" UTILS_BIN="$UTILS_BIN" INPUT_SIZE="$INPUT_SIZE" STATE_JSON="$PROVER_JSON_FILE" bash "$PREPARE_SH"
+    SIZES_JSON="$SIZES_JSON" STATE_JSON="$PROVER_JSON_FILE" bash "$MEASURE_SH" || warn "Size measurement failed"
+    ok "Sizes report: $SIZES_JSON"
+
     step "[$TARGET] Prover (size ${INPUT_SIZE}):"
     if [[ -z "${LOGGING_RUN:-}" ]]; then
     SHOW_OUTPUT=""
@@ -119,11 +125,6 @@ for target in "${TARGETS[@]}"; do
       bash "$MEASURE_RAM_SCRIPT" -o "$MEM_JSON" -- bash -lc "STATE_JSON=\"$PROVER_JSON_FILE\" bash \"$PROVE_SH\"" || warn "Memory measurement failed"
       ok "Memory report: $MEM_JSON"
     fi
-
-    step "[$TARGET] Size measurement (size ${INPUT_SIZE})"
-    SIZES_JSON="$SYSTEM_DIR/${TARGET}_${INPUT_SIZE}_sizes.json"
-    SIZES_JSON="$SIZES_JSON" STATE_JSON="$PROVER_JSON_FILE" bash "$MEASURE_SH" || warn "Size measurement failed"
-    ok "Sizes report: $SIZES_JSON"
   done
 done
 


### PR DESCRIPTION
# Description

Add CRS size measurement to preprocessing and ensure CRS download time is excluded from prover benchmarks.

## Changes

- Implement `bb_clear_crs()` and `bb_measure_crs_size()` helpers
- Include CRS size in `preprocessing_size` calculation
- Move size measurement before prover benchmark to pre-download CRS

## Related Issues

- Closes #173