### PR TITLE
fix: cairo-m guest compilation 

### DIFF
--- a/cairo-m/Cargo.lock
+++ b/cairo-m/Cargo.lock
@@ -423,8 +423,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-m-common"
-version = "0.1.0-alpha"
-source = "git+https://github.com/kkrt-labs/cairo-m?tag=v0.1.0-alpha.1#c0174020c59232133147282e518d7eb3363cdd7d"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/kkrt-labs/cairo-m?rev=79c1b1e#79c1b1e83f7b959babe3c991eca0902954a31385"
 dependencies = [
  "anyhow",
  "num-traits",
@@ -438,8 +438,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-m-compiler"
-version = "0.1.0-alpha"
-source = "git+https://github.com/kkrt-labs/cairo-m?tag=v0.1.0-alpha.1#c0174020c59232133147282e518d7eb3363cdd7d"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/kkrt-labs/cairo-m?rev=79c1b1e#79c1b1e83f7b959babe3c991eca0902954a31385"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -465,8 +465,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-m-compiler-codegen"
-version = "0.1.0-alpha"
-source = "git+https://github.com/kkrt-labs/cairo-m?tag=v0.1.0-alpha.1#c0174020c59232133147282e518d7eb3363cdd7d"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/kkrt-labs/cairo-m?rev=79c1b1e#79c1b1e83f7b959babe3c991eca0902954a31385"
 dependencies = [
  "cairo-m-common",
  "cairo-m-compiler-diagnostics",
@@ -490,8 +490,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-m-compiler-diagnostics"
-version = "0.1.0-alpha"
-source = "git+https://github.com/kkrt-labs/cairo-m?tag=v0.1.0-alpha.1#c0174020c59232133147282e518d7eb3363cdd7d"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/kkrt-labs/cairo-m?rev=79c1b1e#79c1b1e83f7b959babe3c991eca0902954a31385"
 dependencies = [
  "ariadne",
  "chumsky",
@@ -499,8 +499,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-m-compiler-mir"
-version = "0.1.0-alpha"
-source = "git+https://github.com/kkrt-labs/cairo-m?tag=v0.1.0-alpha.1#c0174020c59232133147282e518d7eb3363cdd7d"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/kkrt-labs/cairo-m?rev=79c1b1e#79c1b1e83f7b959babe3c991eca0902954a31385"
 dependencies = [
  "cairo-m-compiler-diagnostics",
  "cairo-m-compiler-parser",
@@ -516,8 +516,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-m-compiler-parser"
-version = "0.1.0-alpha"
-source = "git+https://github.com/kkrt-labs/cairo-m?tag=v0.1.0-alpha.1#c0174020c59232133147282e518d7eb3363cdd7d"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/kkrt-labs/cairo-m?rev=79c1b1e#79c1b1e83f7b959babe3c991eca0902954a31385"
 dependencies = [
  "ariadne",
  "cairo-m-compiler-diagnostics",
@@ -535,8 +535,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-m-compiler-semantic"
-version = "0.1.0-alpha"
-source = "git+https://github.com/kkrt-labs/cairo-m?tag=v0.1.0-alpha.1#c0174020c59232133147282e518d7eb3363cdd7d"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/kkrt-labs/cairo-m?rev=79c1b1e#79c1b1e83f7b959babe3c991eca0902954a31385"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -561,8 +561,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-m-project"
-version = "0.1.0-alpha"
-source = "git+https://github.com/kkrt-labs/cairo-m?tag=v0.1.0-alpha.1#c0174020c59232133147282e518d7eb3363cdd7d"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/kkrt-labs/cairo-m?rev=79c1b1e#79c1b1e83f7b959babe3c991eca0902954a31385"
 dependencies = [
  "anyhow",
  "ignore",
@@ -575,8 +575,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-m-prover"
-version = "0.1.0-alpha"
-source = "git+https://github.com/kkrt-labs/cairo-m?tag=v0.1.0-alpha.1#c0174020c59232133147282e518d7eb3363cdd7d"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/kkrt-labs/cairo-m?rev=79c1b1e#79c1b1e83f7b959babe3c991eca0902954a31385"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -604,8 +604,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-m-runner"
-version = "0.1.0-alpha"
-source = "git+https://github.com/kkrt-labs/cairo-m?tag=v0.1.0-alpha.1#c0174020c59232133147282e518d7eb3363cdd7d"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/kkrt-labs/cairo-m?rev=79c1b1e#79c1b1e83f7b959babe3c991eca0902954a31385"
 dependencies = [
  "anyhow",
  "cairo-m-common",
@@ -626,8 +626,8 @@ dependencies = [
 
 [[package]]
 name = "cairo-m-test-utils"
-version = "0.1.0-alpha"
-source = "git+https://github.com/kkrt-labs/cairo-m?tag=v0.1.0-alpha.1#c0174020c59232133147282e518d7eb3363cdd7d"
+version = "0.1.0-alpha.1"
+source = "git+https://github.com/kkrt-labs/cairo-m?rev=79c1b1e#79c1b1e83f7b959babe3c991eca0902954a31385"
 dependencies = [
  "once_cell",
  "pulldown-cmark",
@@ -987,6 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1073,6 +1074,7 @@ dependencies = [
  "ff 0.13.1",
  "generic-array",
  "group 0.13.0",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1766,6 +1768,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "pairing"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +1859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,6 +1930,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -3230,6 +3262,7 @@ dependencies = [
  "human-repr",
  "k256",
  "libc",
+ "p256",
  "rand 0.8.5",
  "regex",
  "serde",

--- a/cairo-m/Cargo.toml
+++ b/cairo-m/Cargo.toml
@@ -9,10 +9,10 @@ serde_json = { version = "1.0" }
 utils = { path = "../utils" }
 
 # Cairo
-cairo-m-common = { git = "https://github.com/kkrt-labs/cairo-m", tag = "v0.1.0-alpha.1" }
-cairo-m-runner = { git = "https://github.com/kkrt-labs/cairo-m", tag = "v0.1.0-alpha.1" }
-cairo-m-prover = { git = "https://github.com/kkrt-labs/cairo-m", tag = "v0.1.0-alpha.1" }
-cairo-m-compiler = { git = "https://github.com/kkrt-labs/cairo-m", tag = "v0.1.0-alpha.1" }
+cairo-m-common = { git = "https://github.com/kkrt-labs/cairo-m", rev = "79c1b1e" }
+cairo-m-runner = { git = "https://github.com/kkrt-labs/cairo-m", rev = "79c1b1e" }
+cairo-m-prover = { git = "https://github.com/kkrt-labs/cairo-m", rev = "79c1b1e" }
+cairo-m-compiler = { git = "https://github.com/kkrt-labs/cairo-m", rev = "79c1b1e" }
 stwo-prover = { git = "https://github.com/starkware-libs/stwo", features = ["parallel"], rev = "ab57a1c" }
 
 [dev-dependencies]

--- a/cairo-m/benches/sha256_bench.rs
+++ b/cairo-m/benches/sha256_bench.rs
@@ -25,12 +25,12 @@ utils::define_benchmark_harness!(
     { compile_program() },
     |input_size, program: &Program| { prepare(input_size, program) },
     |_, _| 0,
-    |(program, (entrypoint_name, runner_inputs)), _: &&Program| {
+    |(program, (entrypoint_name, runner_inputs)), _| {
         prove(program, (entrypoint_name, runner_inputs))
     },
     |_, proof, _| { verify(proof) },
-    |(compiled_program, _), _: &&Program| { compiled_program.len() },
-    |proof, _: &&Program| proof.stark_proof.size_estimate(),
+    |(compiled_program, _), _| { compiled_program.len() },
+    |proof, _| proof.stark_proof.size_estimate(),
     |(program, (entrypoint_name, runner_inputs)): &(Program, (String, Vec<InputValue>))| {
         // Run/Execute the program
         let runner_output = run_cairo_program(

--- a/cairo-m/benches/sha256_bench.rs
+++ b/cairo-m/benches/sha256_bench.rs
@@ -1,4 +1,4 @@
-use cairo_m::{prepare, prove, verify};
+use cairo_m::{compile_program, prepare, prove, verify};
 use cairo_m_common::{InputValue, Program};
 use cairo_m_prover::{adapter::import_from_runner_output, public_data::PublicData};
 use cairo_m_runner::run_cairo_program;
@@ -22,14 +22,15 @@ utils::define_benchmark_harness!(
         AuditStatus::NotAudited, // https://github.com/kkrt-labs/cairo-m/?tab=readme-ov-file#about
         Some("Cairo ISA"), // https://github.com/kkrt-labs/cairo-m/blob/main/docs/design.md
     ),
-    |input_size| { prepare(input_size) },
-    |_| 0,
-    |(program, (entrypoint_name, runner_inputs))| {
+    { compile_program() },
+    |input_size, program: &Program| { prepare(input_size, program) },
+    |_, _| 0,
+    |(program, (entrypoint_name, runner_inputs)), _: &&Program| {
         prove(program, (entrypoint_name, runner_inputs))
     },
-    |_, proof| { verify(proof) },
-    |(compiled_program, _)| { compiled_program.len() },
-    |proof| proof.stark_proof.size_estimate(),
+    |_, proof, _| { verify(proof) },
+    |(compiled_program, _), _: &&Program| { compiled_program.len() },
+    |proof, _: &&Program| proof.stark_proof.size_estimate(),
     |(program, (entrypoint_name, runner_inputs)): &(Program, (String, Vec<InputValue>))| {
         // Run/Execute the program
         let runner_output = run_cairo_program(

--- a/cairo-m/src/bin/sha256_mem.rs
+++ b/cairo-m/src/bin/sha256_mem.rs
@@ -1,4 +1,4 @@
-use cairo_m::{prepare, prove};
+use cairo_m::{compile_program, prepare, prove};
 use clap::Parser;
 
 #[derive(Parser, Debug)]
@@ -15,6 +15,6 @@ fn main() {
 }
 
 fn sha256_mem(input_size: usize) {
-    let (program, (entrypoint_name, runner_inputs)) = prepare(input_size);
+    let (program, (entrypoint_name, runner_inputs)) = prepare(input_size, &compile_program());
     let _ = prove(&program, (&entrypoint_name, &runner_inputs));
 }


### PR DESCRIPTION
# Description

Separate `cairo-m` program compilation from input preparation.

## Changes

- Pin cairo-m dependencies to rev `79c1b1e`
- Extract `compile_program()` as a separate function
- Update benchmark harness to use separate compile and prepare phases
- Update `sha256_mem.rs` binary to use the new API

## Related Issues

- Resolves #136