### PR TITLE
feat(provekit): add Keccak benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2197,7 +2197,7 @@ dependencies = [
 [[package]]
 name = "block-multiplier"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=d7deea66c41d56c1d411dd799d0d6066272323e4#d7deea66c41d56c1d411dd799d0d6066272323e4"
+source = "git+https://github.com/worldfnd/ProveKit?rev=f8728dbe041648b17bfe17e04776edc95210bc49#f8728dbe041648b17bfe17e04776edc95210bc49"
 dependencies = [
  "block-multiplier-codegen",
  "fp-rounding",
@@ -2208,7 +2208,7 @@ dependencies = [
 [[package]]
 name = "block-multiplier-codegen"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=d7deea66c41d56c1d411dd799d0d6066272323e4#d7deea66c41d56c1d411dd799d0d6066272323e4"
+source = "git+https://github.com/worldfnd/ProveKit?rev=f8728dbe041648b17bfe17e04776edc95210bc49#f8728dbe041648b17bfe17e04776edc95210bc49"
 dependencies = [
  "hla",
 ]
@@ -4226,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "fp-rounding"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=d7deea66c41d56c1d411dd799d0d6066272323e4#d7deea66c41d56c1d411dd799d0d6066272323e4"
+source = "git+https://github.com/worldfnd/ProveKit?rev=f8728dbe041648b17bfe17e04776edc95210bc49#f8728dbe041648b17bfe17e04776edc95210bc49"
 
 [[package]]
 name = "fs_extra"
@@ -4911,7 +4911,7 @@ checksum = "bcaaec4551594c969335c98c903c1397853d4198408ea609190f420500f6be71"
 [[package]]
 name = "hla"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=d7deea66c41d56c1d411dd799d0d6066272323e4#d7deea66c41d56c1d411dd799d0d6066272323e4"
+source = "git+https://github.com/worldfnd/ProveKit?rev=f8728dbe041648b17bfe17e04776edc95210bc49#f8728dbe041648b17bfe17e04776edc95210bc49"
 dependencies = [
  "paste",
 ]
@@ -6856,6 +6856,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "ntt"
+version = "0.1.0"
+source = "git+https://github.com/worldfnd/ProveKit?rev=f8728dbe041648b17bfe17e04776edc95210bc49#f8728dbe041648b17bfe17e04776edc95210bc49"
+dependencies = [
+ "ark-bn254",
+ "ark-ff 0.5.0",
+ "rayon",
 ]
 
 [[package]]
@@ -9444,7 +9454,7 @@ dependencies = [
 [[package]]
 name = "provekit-common"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=d7deea66c41d56c1d411dd799d0d6066272323e4#d7deea66c41d56c1d411dd799d0d6066272323e4"
+source = "git+https://github.com/worldfnd/ProveKit?rev=f8728dbe041648b17bfe17e04776edc95210bc49#f8728dbe041648b17bfe17e04776edc95210bc49"
 dependencies = [
  "acir",
  "anyhow",
@@ -9456,7 +9466,6 @@ dependencies = [
  "bytes",
  "hex",
  "itertools 0.14.0",
- "noir_artifact_cli",
  "noirc_abi",
  "postcard",
  "rand 0.8.5",
@@ -9477,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "provekit-prover"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=d7deea66c41d56c1d411dd799d0d6066272323e4#d7deea66c41d56c1d411dd799d0d6066272323e4"
+source = "git+https://github.com/worldfnd/ProveKit?rev=f8728dbe041648b17bfe17e04776edc95210bc49#f8728dbe041648b17bfe17e04776edc95210bc49"
 dependencies = [
  "acir",
  "anyhow",
@@ -9485,6 +9494,7 @@ dependencies = [
  "ark-std 0.5.0",
  "bn254_blackbox_solver",
  "nargo",
+ "noir_artifact_cli",
  "noirc_abi",
  "provekit-common",
  "rand 0.9.2",
@@ -9498,14 +9508,16 @@ dependencies = [
 [[package]]
 name = "provekit-r1cs-compiler"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=d7deea66c41d56c1d411dd799d0d6066272323e4#d7deea66c41d56c1d411dd799d0d6066272323e4"
+source = "git+https://github.com/worldfnd/ProveKit?rev=f8728dbe041648b17bfe17e04776edc95210bc49#f8728dbe041648b17bfe17e04776edc95210bc49"
 dependencies = [
  "acir",
  "anyhow",
+ "ark-bn254",
  "ark-ff 0.5.0",
  "ark-std 0.5.0",
  "noirc_abi",
  "noirc_artifacts",
+ "ntt",
  "postcard",
  "provekit-common",
  "serde",
@@ -9517,12 +9529,11 @@ dependencies = [
 [[package]]
 name = "provekit-verifier"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=d7deea66c41d56c1d411dd799d0d6066272323e4#d7deea66c41d56c1d411dd799d0d6066272323e4"
+source = "git+https://github.com/worldfnd/ProveKit?rev=f8728dbe041648b17bfe17e04776edc95210bc49#f8728dbe041648b17bfe17e04776edc95210bc49"
 dependencies = [
  "anyhow",
  "ark-std 0.5.0",
  "provekit-common",
- "provekit-prover",
  "spongefish",
  "tracing",
  "whir",
@@ -11301,13 +11312,12 @@ checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 [[package]]
 name = "skyscraper"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=d7deea66c41d56c1d411dd799d0d6066272323e4#d7deea66c41d56c1d411dd799d0d6066272323e4"
+source = "git+https://github.com/worldfnd/ProveKit?rev=f8728dbe041648b17bfe17e04776edc95210bc49#f8728dbe041648b17bfe17e04776edc95210bc49"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.5.0",
  "block-multiplier",
  "fp-rounding",
- "proptest",
  "rayon",
  "seq-macro",
  "zerocopy",
@@ -11869,7 +11879,7 @@ dependencies = [
 [[package]]
 name = "spongefish"
 version = "0.2.0-alpha"
-source = "git+https://github.com/arkworks-rs/spongefish#fce4bfed23b2deb9a9f174178b6c9f59f580cc81"
+source = "git+https://github.com/arkworks-rs/spongefish?rev=ecb4f08373ed930175585c856517efdb1851fb47#ecb4f08373ed930175585c856517efdb1851fb47"
 dependencies = [
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
@@ -11887,7 +11897,7 @@ dependencies = [
 [[package]]
 name = "spongefish-pow"
 version = "0.1.0-alpha"
-source = "git+https://github.com/arkworks-rs/spongefish#fce4bfed23b2deb9a9f174178b6c9f59f580cc81"
+source = "git+https://github.com/arkworks-rs/spongefish?rev=ecb4f08373ed930175585c856517efdb1851fb47#ecb4f08373ed930175585c856517efdb1851fb47"
 dependencies = [
  "blake3",
  "bytemuck",
@@ -13506,7 +13516,7 @@ dependencies = [
 [[package]]
 name = "whir"
 version = "0.1.0"
-source = "git+https://github.com/WizardOfMenlo/whir/?rev=48fc0909d6a0d803d61c35b0c18499ad704da211#48fc0909d6a0d803d61c35b0c18499ad704da211"
+source = "git+https://github.com/WizardOfMenlo/whir/?rev=cf1599b56ff50e09142ebe6d2e2fbd86875c9986#cf1599b56ff50e09142ebe6d2e2fbd86875c9986"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ff 0.5.0",

--- a/provekit/Cargo.toml
+++ b/provekit/Cargo.toml
@@ -8,10 +8,10 @@ rand = { workspace = true }
 utils = { workspace = true }
 criterion = { workspace = true }
 clap = { workspace = true }
-provekit-common = { git = "https://github.com/worldfnd/ProveKit", rev = "d7deea66c41d56c1d411dd799d0d6066272323e4"}
-provekit-r1cs-compiler = { git = "https://github.com/worldfnd/ProveKit", rev = "d7deea66c41d56c1d411dd799d0d6066272323e4"}
-provekit-prover = { git = "https://github.com/worldfnd/ProveKit", rev = "d7deea66c41d56c1d411dd799d0d6066272323e4"}
-provekit-verifier = { git = "https://github.com/worldfnd/ProveKit", rev = "d7deea66c41d56c1d411dd799d0d6066272323e4"}
+provekit-common = { git = "https://github.com/worldfnd/ProveKit", rev = "f8728dbe041648b17bfe17e04776edc95210bc49"}
+provekit-r1cs-compiler = { git = "https://github.com/worldfnd/ProveKit", rev = "f8728dbe041648b17bfe17e04776edc95210bc49"}
+provekit-prover = { git = "https://github.com/worldfnd/ProveKit", rev = "f8728dbe041648b17bfe17e04776edc95210bc49"}
+provekit-verifier = { git = "https://github.com/worldfnd/ProveKit", rev = "f8728dbe041648b17bfe17e04776edc95210bc49"}
 
 [[bin]]
 name = "sha256_mem_provekit"
@@ -25,6 +25,10 @@ path = "src/bin/ecdsa_mem.rs"
 name = "poseidon_mem_provekit"
 path = "src/bin/poseidon_mem.rs"
 
+[[bin]]
+name = "keccak_mem_provekit"
+path = "src/bin/keccak_mem.rs"
+
 [[bench]]
 name = "sha256"
 harness = false
@@ -35,4 +39,8 @@ harness = false
 
 [[bench]]
 name = "poseidon"
+harness = false
+
+[[bench]]
+name = "keccak"
 harness = false

--- a/provekit/benches/keccak.rs
+++ b/provekit/benches/keccak.rs
@@ -1,0 +1,18 @@
+use provekit::{PROVEKIT_PROPS, prepare_keccak, preprocessing_size, prove, verify};
+use utils::harness::ProvingSystem;
+
+utils::define_benchmark_harness!(
+    BenchTarget::Keccak,
+    ProvingSystem::Provekit,
+    None,
+    "keccak_mem_provekit",
+    PROVEKIT_PROPS,
+    prepare_keccak,
+    |(proof_scheme, _, _)| { proof_scheme.r1cs.num_constraints() },
+    |(proof_scheme, toml_path, _)| { prove(proof_scheme, toml_path) },
+    |(proof_scheme, _, _), proof| {
+        verify(proof, proof_scheme).unwrap();
+    },
+    |(_, _, circuit_path)| { preprocessing_size(circuit_path) },
+    |proof| { proof.whir_r1cs_proof.transcript.len() }
+);

--- a/provekit/circuits/Nargo.toml
+++ b/provekit/circuits/Nargo.toml
@@ -3,5 +3,6 @@ members = [
     "hash/sha256-provekit/noir-native-sha256",
     "hash/sha256-provekit/sha256_var_input",
     "hash/poseidon",
+    "hash/keccak",
     "ecdsa/p256_bigcurve",
 ]

--- a/provekit/circuits/hash/keccak/Nargo.toml
+++ b/provekit/circuits/hash/keccak/Nargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "keccak"
+type = "bin"

--- a/provekit/circuits/hash/keccak/src/main.nr
+++ b/provekit/circuits/hash/keccak/src/main.nr
@@ -1,0 +1,227 @@
+// Keccak-256
+// Uses 32-bit operations
+
+// 64-bit lane split into two u32 halves (little-endian)
+struct Lane {
+    lo: u32,
+    hi: u32,
+}
+
+impl Lane {
+    fn zero() -> Self {
+        Lane { lo: 0, hi: 0 }
+    }
+
+    fn xor(self, other: Self) -> Self {
+        Lane { lo: self.lo ^ other.lo, hi: self.hi ^ other.hi }
+    }
+
+    fn and(self, other: Self) -> Self {
+        Lane { lo: self.lo & other.lo, hi: self.hi & other.hi }
+    }
+
+    fn not(self) -> Self {
+        Lane { lo: !self.lo, hi: !self.hi }
+    }
+
+    fn rotl(self, n: u8) -> Self {
+        if n == 0 {
+            self
+        } else if n == 32 {
+            Lane { lo: self.hi, hi: self.lo }
+        } else if n < 32 {
+            let n32 = n as u32;
+            let complement = 32 - n32;
+            Lane {
+                lo: (self.lo << n32) | (self.hi >> complement),
+                hi: (self.hi << n32) | (self.lo >> complement),
+            }
+        } else {
+            let m = n - 32;
+            let m32 = m as u32;
+            let complement = 32 - m32;
+            Lane {
+                lo: (self.hi << m32) | (self.lo >> complement),
+                hi: (self.lo << m32) | (self.hi >> complement),
+            }
+        }
+    }
+}
+
+// 5x5 grid of 64-bit lanes = 1600-bit state
+struct State {
+    lanes: [Lane; 25],
+}
+
+impl State {
+    fn zero() -> Self {
+        State { lanes: [Lane::zero(); 25] }
+    }
+}
+
+fn get_round_constant(round: u32) -> Lane {
+    if round == 0 { Lane { lo: 0x00000001, hi: 0x00000000 } }
+    else if round == 1 { Lane { lo: 0x00008082, hi: 0x00000000 } }
+    else if round == 2 { Lane { lo: 0x0000808A, hi: 0x80000000 } }
+    else if round == 3 { Lane { lo: 0x80008000, hi: 0x80000000 } }
+    else if round == 4 { Lane { lo: 0x0000808B, hi: 0x00000000 } }
+    else if round == 5 { Lane { lo: 0x80000001, hi: 0x00000000 } }
+    else if round == 6 { Lane { lo: 0x80008081, hi: 0x80000000 } }
+    else if round == 7 { Lane { lo: 0x00008009, hi: 0x80000000 } }
+    else if round == 8 { Lane { lo: 0x0000008A, hi: 0x00000000 } }
+    else if round == 9 { Lane { lo: 0x00000088, hi: 0x00000000 } }
+    else if round == 10 { Lane { lo: 0x80008009, hi: 0x00000000 } }
+    else if round == 11 { Lane { lo: 0x8000000A, hi: 0x00000000 } }
+    else if round == 12 { Lane { lo: 0x8000808B, hi: 0x00000000 } }
+    else if round == 13 { Lane { lo: 0x0000008B, hi: 0x80000000 } }
+    else if round == 14 { Lane { lo: 0x00008089, hi: 0x80000000 } }
+    else if round == 15 { Lane { lo: 0x00008003, hi: 0x80000000 } }
+    else if round == 16 { Lane { lo: 0x00008002, hi: 0x80000000 } }
+    else if round == 17 { Lane { lo: 0x00000080, hi: 0x80000000 } }
+    else if round == 18 { Lane { lo: 0x0000800A, hi: 0x00000000 } }
+    else if round == 19 { Lane { lo: 0x8000000A, hi: 0x80000000 } }
+    else if round == 20 { Lane { lo: 0x80008081, hi: 0x80000000 } }
+    else if round == 21 { Lane { lo: 0x00008080, hi: 0x80000000 } }
+    else if round == 22 { Lane { lo: 0x80000001, hi: 0x00000000 } }
+    else { Lane { lo: 0x80008008, hi: 0x80000000 } }
+}
+
+// Keccak-f[1600] permutation: 24 rounds of theta, rho, pi, chi, iota
+fn keccakf1600(state: State) -> State {
+    let mut a = state.lanes;
+
+    for round in 0..24 {
+        // theta: column parity mixing
+        let c0 = a[0].xor(a[5]).xor(a[10]).xor(a[15]).xor(a[20]);
+        let c1 = a[1].xor(a[6]).xor(a[11]).xor(a[16]).xor(a[21]);
+        let c2 = a[2].xor(a[7]).xor(a[12]).xor(a[17]).xor(a[22]);
+        let c3 = a[3].xor(a[8]).xor(a[13]).xor(a[18]).xor(a[23]);
+        let c4 = a[4].xor(a[9]).xor(a[14]).xor(a[19]).xor(a[24]);
+
+        let d0 = c4.xor(c1.rotl(1));
+        let d1 = c0.xor(c2.rotl(1));
+        let d2 = c1.xor(c3.rotl(1));
+        let d3 = c2.xor(c4.rotl(1));
+        let d4 = c3.xor(c0.rotl(1));
+
+        a[0] = a[0].xor(d0); a[1] = a[1].xor(d1); a[2] = a[2].xor(d2); a[3] = a[3].xor(d3); a[4] = a[4].xor(d4);
+        a[5] = a[5].xor(d0); a[6] = a[6].xor(d1); a[7] = a[7].xor(d2); a[8] = a[8].xor(d3); a[9] = a[9].xor(d4);
+        a[10] = a[10].xor(d0); a[11] = a[11].xor(d1); a[12] = a[12].xor(d2); a[13] = a[13].xor(d3); a[14] = a[14].xor(d4);
+        a[15] = a[15].xor(d0); a[16] = a[16].xor(d1); a[17] = a[17].xor(d2); a[18] = a[18].xor(d3); a[19] = a[19].xor(d4);
+        a[20] = a[20].xor(d0); a[21] = a[21].xor(d1); a[22] = a[22].xor(d2); a[23] = a[23].xor(d3); a[24] = a[24].xor(d4);
+
+        // rho: rotate each lane, pi: permute lane positions
+        let mut b: [Lane; 25] = [Lane::zero(); 25];
+        b[0] = a[0];
+        b[10] = a[1].rotl(1); b[7] = a[10].rotl(3); b[11] = a[7].rotl(6); b[17] = a[11].rotl(10);
+        b[18] = a[17].rotl(15); b[3] = a[18].rotl(21); b[5] = a[3].rotl(28); b[16] = a[5].rotl(36);
+        b[8] = a[16].rotl(45); b[21] = a[8].rotl(55); b[24] = a[21].rotl(2); b[4] = a[24].rotl(14);
+        b[15] = a[4].rotl(27); b[23] = a[15].rotl(41); b[19] = a[23].rotl(56); b[13] = a[19].rotl(8);
+        b[12] = a[13].rotl(25); b[2] = a[12].rotl(43); b[20] = a[2].rotl(62); b[14] = a[20].rotl(18);
+        b[22] = a[14].rotl(39); b[9] = a[22].rotl(61); b[6] = a[9].rotl(20); b[1] = a[6].rotl(44);
+        a = b;
+
+        // chi: non-linear mixing (a[i] ^= ~a[i+1] & a[i+2])
+        let s = a;
+        a[0] = s[0].xor(s[1].not().and(s[2])); a[1] = s[1].xor(s[2].not().and(s[3]));
+        a[2] = s[2].xor(s[3].not().and(s[4])); a[3] = s[3].xor(s[4].not().and(s[0]));
+        a[4] = s[4].xor(s[0].not().and(s[1]));
+        a[5] = s[5].xor(s[6].not().and(s[7])); a[6] = s[6].xor(s[7].not().and(s[8]));
+        a[7] = s[7].xor(s[8].not().and(s[9])); a[8] = s[8].xor(s[9].not().and(s[5]));
+        a[9] = s[9].xor(s[5].not().and(s[6]));
+        a[10] = s[10].xor(s[11].not().and(s[12])); a[11] = s[11].xor(s[12].not().and(s[13]));
+        a[12] = s[12].xor(s[13].not().and(s[14])); a[13] = s[13].xor(s[14].not().and(s[10]));
+        a[14] = s[14].xor(s[10].not().and(s[11]));
+        a[15] = s[15].xor(s[16].not().and(s[17])); a[16] = s[16].xor(s[17].not().and(s[18]));
+        a[17] = s[17].xor(s[18].not().and(s[19])); a[18] = s[18].xor(s[19].not().and(s[15]));
+        a[19] = s[19].xor(s[15].not().and(s[16]));
+        a[20] = s[20].xor(s[21].not().and(s[22])); a[21] = s[21].xor(s[22].not().and(s[23]));
+        a[22] = s[22].xor(s[23].not().and(s[24])); a[23] = s[23].xor(s[24].not().and(s[20]));
+        a[24] = s[24].xor(s[20].not().and(s[21]));
+
+        // iota: XOR round constant into lane 0
+        a[0] = a[0].xor(get_round_constant(round));
+    }
+
+    State { lanes: a }
+}
+
+fn le_bytes_to_lane(b0: u8, b1: u8, b2: u8, b3: u8, b4: u8, b5: u8, b6: u8, b7: u8) -> Lane {
+    let lo = (b0 as u32) | ((b1 as u32) << 8) | ((b2 as u32) << 16) | ((b3 as u32) << 24);
+    let hi = (b4 as u32) | ((b5 as u32) << 8) | ((b6 as u32) << 16) | ((b7 as u32) << 24);
+    Lane { lo, hi }
+}
+
+fn state_to_32_bytes(state: State) -> [u8; 32] {
+    let l0 = state.lanes[0];
+    let l1 = state.lanes[1];
+    let l2 = state.lanes[2];
+    let l3 = state.lanes[3];
+    [
+        (l0.lo & 0xFF) as u8, ((l0.lo >> 8) & 0xFF) as u8, ((l0.lo >> 16) & 0xFF) as u8, ((l0.lo >> 24) & 0xFF) as u8,
+        (l0.hi & 0xFF) as u8, ((l0.hi >> 8) & 0xFF) as u8, ((l0.hi >> 16) & 0xFF) as u8, ((l0.hi >> 24) & 0xFF) as u8,
+        (l1.lo & 0xFF) as u8, ((l1.lo >> 8) & 0xFF) as u8, ((l1.lo >> 16) & 0xFF) as u8, ((l1.lo >> 24) & 0xFF) as u8,
+        (l1.hi & 0xFF) as u8, ((l1.hi >> 8) & 0xFF) as u8, ((l1.hi >> 16) & 0xFF) as u8, ((l1.hi >> 24) & 0xFF) as u8,
+        (l2.lo & 0xFF) as u8, ((l2.lo >> 8) & 0xFF) as u8, ((l2.lo >> 16) & 0xFF) as u8, ((l2.lo >> 24) & 0xFF) as u8,
+        (l2.hi & 0xFF) as u8, ((l2.hi >> 8) & 0xFF) as u8, ((l2.hi >> 16) & 0xFF) as u8, ((l2.hi >> 24) & 0xFF) as u8,
+        (l3.lo & 0xFF) as u8, ((l3.lo >> 8) & 0xFF) as u8, ((l3.lo >> 16) & 0xFF) as u8, ((l3.lo >> 24) & 0xFF) as u8,
+        (l3.hi & 0xFF) as u8, ((l3.hi >> 8) & 0xFF) as u8, ((l3.hi >> 16) & 0xFF) as u8, ((l3.hi >> 24) & 0xFF) as u8,
+    ]
+}
+
+// XOR 136-byte block into state and apply permutation (rate = 1088 bits)
+fn absorb_block(state: State, block: [u8; 136]) -> State {
+    let mut st = state;
+    for lane in 0..17 {
+        let base = lane * 8;
+        let lane_val = le_bytes_to_lane(
+            block[base], block[base + 1], block[base + 2], block[base + 3],
+            block[base + 4], block[base + 5], block[base + 6], block[base + 7]
+        );
+        st.lanes[lane] = st.lanes[lane].xor(lane_val);
+    }
+    keccakf1600(st)
+}
+
+// Sponge construction: absorb message in 136-byte blocks, squeeze 32 bytes.
+// Padding: append 0x01 after message, 0x80 at end of block.
+fn keccak256<let N: u32>(msg: [u8; N], message_size: u32) -> [u8; 32] {
+    let mut state = State::zero();
+    let num_full_blocks = message_size / 136;
+
+    // Process up to 16 blocks (supports messages up to 2048 bytes)
+    for block_idx in 0..16 {
+        let bidx = block_idx as u32;
+        if bidx <= num_full_blocks {
+            let mut block: [u8; 136] = [0; 136];
+            let base = bidx * 136;
+            let is_final = bidx == num_full_blocks;
+
+            for i in 0..136 {
+                let idx = base + (i as u32);
+                if (idx < message_size) & (idx < N) {
+                    block[i] = msg[idx];
+                }
+            }
+
+            if is_final {
+                let pad_pos = message_size - base;
+                for i in 0..136 {
+                    if (i as u32) == pad_pos {
+                        block[i] ^= 0x01;
+                    }
+                }
+                block[135] ^= 0x80;
+            }
+
+            state = absorb_block(state, block);
+        }
+    }
+
+    state_to_32_bytes(state)
+}
+
+fn main(msg: [u8; 512], message_size: u64, result: [u8; 32]) {
+    let digest = keccak256(msg, message_size as u32);
+    assert(digest == result);
+}

--- a/provekit/circuits/hash/keccak/src/main.nr
+++ b/provekit/circuits/hash/keccak/src/main.nr
@@ -59,32 +59,32 @@ impl State {
     }
 }
 
-fn get_round_constant(round: u32) -> Lane {
-    if round == 0 { Lane { lo: 0x00000001, hi: 0x00000000 } }
-    else if round == 1 { Lane { lo: 0x00008082, hi: 0x00000000 } }
-    else if round == 2 { Lane { lo: 0x0000808A, hi: 0x80000000 } }
-    else if round == 3 { Lane { lo: 0x80008000, hi: 0x80000000 } }
-    else if round == 4 { Lane { lo: 0x0000808B, hi: 0x00000000 } }
-    else if round == 5 { Lane { lo: 0x80000001, hi: 0x00000000 } }
-    else if round == 6 { Lane { lo: 0x80008081, hi: 0x80000000 } }
-    else if round == 7 { Lane { lo: 0x00008009, hi: 0x80000000 } }
-    else if round == 8 { Lane { lo: 0x0000008A, hi: 0x00000000 } }
-    else if round == 9 { Lane { lo: 0x00000088, hi: 0x00000000 } }
-    else if round == 10 { Lane { lo: 0x80008009, hi: 0x00000000 } }
-    else if round == 11 { Lane { lo: 0x8000000A, hi: 0x00000000 } }
-    else if round == 12 { Lane { lo: 0x8000808B, hi: 0x00000000 } }
-    else if round == 13 { Lane { lo: 0x0000008B, hi: 0x80000000 } }
-    else if round == 14 { Lane { lo: 0x00008089, hi: 0x80000000 } }
-    else if round == 15 { Lane { lo: 0x00008003, hi: 0x80000000 } }
-    else if round == 16 { Lane { lo: 0x00008002, hi: 0x80000000 } }
-    else if round == 17 { Lane { lo: 0x00000080, hi: 0x80000000 } }
-    else if round == 18 { Lane { lo: 0x0000800A, hi: 0x00000000 } }
-    else if round == 19 { Lane { lo: 0x8000000A, hi: 0x80000000 } }
-    else if round == 20 { Lane { lo: 0x80008081, hi: 0x80000000 } }
-    else if round == 21 { Lane { lo: 0x00008080, hi: 0x80000000 } }
-    else if round == 22 { Lane { lo: 0x80000001, hi: 0x00000000 } }
-    else { Lane { lo: 0x80008008, hi: 0x80000000 } }
-}
+global ROUND_CONSTANTS: [Lane; 24] = [
+    Lane { lo: 0x00000001, hi: 0x00000000 },
+    Lane { lo: 0x00008082, hi: 0x00000000 },
+    Lane { lo: 0x0000808A, hi: 0x80000000 },
+    Lane { lo: 0x80008000, hi: 0x80000000 },
+    Lane { lo: 0x0000808B, hi: 0x00000000 },
+    Lane { lo: 0x80000001, hi: 0x00000000 },
+    Lane { lo: 0x80008081, hi: 0x80000000 },
+    Lane { lo: 0x00008009, hi: 0x80000000 },
+    Lane { lo: 0x0000008A, hi: 0x00000000 },
+    Lane { lo: 0x00000088, hi: 0x00000000 },
+    Lane { lo: 0x80008009, hi: 0x00000000 },
+    Lane { lo: 0x8000000A, hi: 0x00000000 },
+    Lane { lo: 0x8000808B, hi: 0x00000000 },
+    Lane { lo: 0x0000008B, hi: 0x80000000 },
+    Lane { lo: 0x00008089, hi: 0x80000000 },
+    Lane { lo: 0x00008003, hi: 0x80000000 },
+    Lane { lo: 0x00008002, hi: 0x80000000 },
+    Lane { lo: 0x00000080, hi: 0x80000000 },
+    Lane { lo: 0x0000800A, hi: 0x00000000 },
+    Lane { lo: 0x8000000A, hi: 0x80000000 },
+    Lane { lo: 0x80008081, hi: 0x80000000 },
+    Lane { lo: 0x00008080, hi: 0x80000000 },
+    Lane { lo: 0x80000001, hi: 0x00000000 },
+    Lane { lo: 0x80008008, hi: 0x80000000 },
+];
 
 // Keccak-f[1600] permutation: 24 rounds of theta, rho, pi, chi, iota
 fn keccakf1600(state: State) -> State {
@@ -140,7 +140,7 @@ fn keccakf1600(state: State) -> State {
         a[24] = s[24].xor(s[20].not().and(s[21]));
 
         // iota: XOR round constant into lane 0
-        a[0] = a[0].xor(get_round_constant(round));
+        a[0] = a[0].xor(ROUND_CONSTANTS[round]);
     }
 
     State { lanes: a }

--- a/provekit/src/bin/keccak_mem.rs
+++ b/provekit/src/bin/keccak_mem.rs
@@ -1,0 +1,14 @@
+use clap::Parser;
+use provekit::{prepare_keccak, prove};
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long)]
+    input_size: usize,
+}
+
+fn main() {
+    let args = Args::parse();
+    let (scheme, toml_path, _pre_size) = prepare_keccak(args.input_size);
+    let _proof = prove(&scheme, &toml_path);
+}


### PR DESCRIPTION
# Description

- Adds provekit keccak benchmarks
- Manually implements keccak based on [this](https://github.com/alxkzmn/provekit/blob/whir-based/noir-examples/keccak/src/main.nr), since provekit has no support for keccak precompile.
- Bumps provekit rev

## Related Issues

- #208 