### PR TITLE
chore(ligetron): update submodule to v1.4.0 and adjust build setup

### DIFF
--- a/.github/actions/install-ligero/action.yml
+++ b/.github/actions/install-ligero/action.yml
@@ -1,5 +1,5 @@
 name: Ligero setup & build (macOS)
-description: Install deps (Dawn, WABT, emsdk), then build ligero-prover SDK+native.
+description: Install deps (Dawn, emsdk), then build ligero-prover SDK+native.
 
 inputs:
   ligero_path:
@@ -10,10 +10,6 @@ inputs:
     description: Dawn commit to build.
     required: false
     default: cec4482eccee45696a7c0019e750c77f101ced04
-  wabt_version:
-    description: WABT version to install.
-    required: false
-    default: "1.0.39"
   install_prefix:
     description: Where to install Dawn/WABT (used as CMAKE_PREFIX_PATH).
     required: false
@@ -50,7 +46,7 @@ runs:
       run: |
         set -euo pipefail
         NEEDS=()
-        for pkg in cmake ninja gmp mpfr libomp llvm boost nlohmann-json ccache; do
+        for pkg in cmake ninja gmp mpfr libomp llvm boost nlohmann-json ccache wabt; do
           brew list --versions "$pkg" >/dev/null 2>&1 || NEEDS+=("$pkg")
         done
         if [[ ${#NEEDS[@]} -gt 0 ]]; then
@@ -84,13 +80,13 @@ runs:
         echo "CCACHE_MAXSIZE=5G" >> $GITHUB_ENV
         ccache -s || true
 
-    # Cache ALL installed deps (Dawn + WABT) in one folder keyed by Dawn commit and WABT version.
+    # Cache Dawn install folder keyed by Dawn commit.
     - name: Cache deps install
       id: cache-deps
       uses: actions/cache@v4
       with:
         path: ${{ inputs.install_prefix }}
-        key: deps-macos-dawn-${{ inputs.dawn_commit }}-wabt-${{ inputs.wabt_version }}-v1
+        key: deps-macos-${{ inputs.dawn_commit }}-v1
 
     # ---------- Dawn ----------
     - name: Build & install Dawn
@@ -113,29 +109,6 @@ runs:
               -DDAWN_BUILD_TESTS=OFF \
               -DDAWN_BUILD_SAMPLES=OFF \
               -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -DCMAKE_INSTALL_PREFIX="${{ inputs.install_prefix }}" ..
-        cmake --build . --parallel
-        cmake --install .
-
-    # ---------- WABT ----------
-    - name: Build & install WABT
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        set -euo pipefail
-        cd third_party
-        if [ ! -d wabt ]; then
-          git clone https://github.com/WebAssembly/wabt.git
-        fi
-        cd wabt
-        git fetch --all --tags
-        git checkout "${{ inputs.wabt_version }}"
-        git submodule update --init
-        mkdir -p build && cd build
-        cmake -G Ninja \
-              -DCMAKE_CXX_COMPILER=clang++ \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_INSTALL_PREFIX="${{ inputs.install_prefix }}" ..

--- a/.github/actions/install-ligero/action.yml
+++ b/.github/actions/install-ligero/action.yml
@@ -9,7 +9,11 @@ inputs:
   dawn_commit:
     description: Dawn commit to build.
     required: false
-    default: 41d631c0cbcd46ddc723222fc80890f4305dbc65
+    default: cec4482eccee45696a7c0019e750c77f101ced04
+  wabt_version:
+    description: WABT version to install.
+    required: false
+    default: "1.0.39"
   install_prefix:
     description: Where to install Dawn/WABT (used as CMAKE_PREFIX_PATH).
     required: false
@@ -20,7 +24,7 @@ outputs:
     description: Path to native build dir
     value: ${{ steps.paths.outputs.build_dir }}
   sdk_build_dir:
-    description: Path to SDK build dir
+    description: Path to SDK build dir (sdk/cpp/build)
     value: ${{ steps.paths.outputs.sdk_build_dir }}
   install_prefix:
     description: Install prefix used for dependencies
@@ -36,7 +40,7 @@ runs:
         set -euo pipefail
         LIGERO="${{ inputs.ligero_path }}"
         echo "build_dir=${LIGERO}/build" >> "$GITHUB_OUTPUT"
-        echo "sdk_build_dir=${LIGERO}/sdk/build" >> "$GITHUB_OUTPUT"
+        echo "sdk_build_dir=${LIGERO}/sdk/cpp/build" >> "$GITHUB_OUTPUT"
 
     - name: Brew deps (conditionally)
       shell: bash
@@ -46,7 +50,7 @@ runs:
       run: |
         set -euo pipefail
         NEEDS=()
-        for pkg in cmake ninja gmp mpfr libomp llvm boost nlohmann-json ccache wabt; do
+        for pkg in cmake ninja gmp mpfr libomp llvm boost nlohmann-json ccache; do
           brew list --versions "$pkg" >/dev/null 2>&1 || NEEDS+=("$pkg")
         done
         if [[ ${#NEEDS[@]} -gt 0 ]]; then
@@ -80,13 +84,13 @@ runs:
         echo "CCACHE_MAXSIZE=5G" >> $GITHUB_ENV
         ccache -s || true
 
-    # Cache ALL installed deps (Dawn + WABT) in one folder keyed by Dawn commit.
+    # Cache ALL installed deps (Dawn + WABT) in one folder keyed by Dawn commit and WABT version.
     - name: Cache deps install
       id: cache-deps
       uses: actions/cache@v4
       with:
         path: ${{ inputs.install_prefix }}
-        key: deps-macos-${{ inputs.dawn_commit }}-v1
+        key: deps-macos-dawn-${{ inputs.dawn_commit }}-wabt-${{ inputs.wabt_version }}-v1
 
     # ---------- Dawn ----------
     - name: Build & install Dawn
@@ -104,10 +108,34 @@ runs:
         mkdir -p release && cd release
         cmake -G Ninja \
               -DDAWN_FETCH_DEPENDENCIES=ON \
+              -DDAWN_BUILD_MONOLITHIC_LIBRARY=STATIC \
               -DDAWN_ENABLE_INSTALL=ON \
               -DDAWN_BUILD_TESTS=OFF \
               -DDAWN_BUILD_SAMPLES=OFF \
               -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_INSTALL_PREFIX="${{ inputs.install_prefix }}" ..
+        cmake --build . --parallel
+        cmake --install .
+
+    # ---------- WABT ----------
+    - name: Build & install WABT
+      if: steps.cache-deps.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd third_party
+        if [ ! -d wabt ]; then
+          git clone https://github.com/WebAssembly/wabt.git
+        fi
+        cd wabt
+        git fetch --all --tags
+        git checkout "${{ inputs.wabt_version }}"
+        git submodule update --init
+        mkdir -p build && cd build
+        cmake -G Ninja \
+              -DCMAKE_CXX_COMPILER=clang++ \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
               -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -DCMAKE_INSTALL_PREFIX="${{ inputs.install_prefix }}" ..
@@ -138,22 +166,22 @@ runs:
       id: cache-sdk
       uses: actions/cache@v4
       with:
-        path: ${{ inputs.ligero_path }}/sdk/build
-        key: sdk-build-${{ runner.os }}-${{ hashFiles(format('{0}/sdk/CMakeLists.txt', inputs.ligero_path)) }}-${{ hashFiles(format('{0}/sdk/src/**', inputs.ligero_path)) }}
+        path: ${{ inputs.ligero_path }}/sdk/cpp/build
+        key: sdk-build-${{ runner.os }}-${{ hashFiles(format('{0}/sdk/cpp/CMakeLists.txt', inputs.ligero_path)) }}-${{ hashFiles(format('{0}/sdk/cpp/src/**', inputs.ligero_path)) }}
 
     - name: Reset SDK CMake cache (avoid stale EMSDK toolchain paths)
       shell: bash
       run: |
         set -euo pipefail
-        rm -f "${{ inputs.ligero_path }}/sdk/build/CMakeCache.txt"
-        rm -rf "${{ inputs.ligero_path }}/sdk/build/CMakeFiles"
+        rm -f "${{ inputs.ligero_path }}/sdk/cpp/build/CMakeCache.txt"
+        rm -rf "${{ inputs.ligero_path }}/sdk/cpp/build/CMakeFiles"
 
     - name: Build SDK (emscripten)
       shell: bash
       run: |
         set -euo pipefail
-        emcmake cmake -S "${{ inputs.ligero_path }}/sdk" -B "${{ inputs.ligero_path }}/sdk/build" -G Ninja
-        cmake --build "${{ inputs.ligero_path }}/sdk/build" --parallel
+        emcmake cmake -S "${{ inputs.ligero_path }}/sdk/cpp" -B "${{ inputs.ligero_path }}/sdk/cpp/build" -G Ninja
+        cmake --build "${{ inputs.ligero_path }}/sdk/cpp/build" --parallel
 
     # ---------- Build native ----------
     - name: Cache native build

--- a/.github/actions/install-ligero/action.yml
+++ b/.github/actions/install-ligero/action.yml
@@ -86,7 +86,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ inputs.install_prefix }}
-        key: deps-macos-${{ inputs.dawn_commit }}-v1
+        key: deps-macos-dawn-${{ inputs.dawn_commit }}-v1
 
     # ---------- Dawn ----------
     - name: Build & install Dawn

--- a/ligetron/common_prepare.sh
+++ b/ligetron/common_prepare.sh
@@ -15,7 +15,7 @@ DIG_TYPE="${2:?}"
 LEN_VALUE="${3:?}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PROGRAM_PATH="${SCRIPT_DIR}/ligero-prover/sdk/build/examples/${TARGET_NAME}.wasm"
+PROGRAM_PATH="${SCRIPT_DIR}/ligero-prover/sdk/cpp/build/examples/${TARGET_NAME}.wasm"
 SHADER_PATH="${SCRIPT_DIR}/ligero-prover/shader"
 
 GEN="$("$UTILS_BIN" "$TARGET_NAME" -n "$INPUT_SIZE")"

--- a/ligetron/measure.sh
+++ b/ligetron/measure.sh
@@ -16,18 +16,18 @@ TARGET_NAME="${BASENAME%%_[0-9]*}"
 # Run one proving cycle to generate artifacts for measurement
 "$SCRIPT_DIR/prove.sh" >/dev/null 2>&1 || true
 
-# In Ligetron, the prover writes a proof file named proof.data in the current working directory.
-proof_path="${PWD}/proof.data"
+# In Ligetron, the prover writes a proof file named proof_data.gz in the current working directory.
+proof_path="${PWD}/proof_data.gz"
 
 if [[ ! -f "$proof_path" ]]; then
-  echo "proof.data not found for Ligero size measurement" >&2
+  echo "proof_data.gz not found for Ligero size measurement" >&2
   exit 1
 fi
 
 proof_size_bytes=$(stat -f %z "$proof_path" 2>/dev/null || stat -c %s "$proof_path")
 
 # Preprocessing artifacts: WASM used by the prover
-WASM_PATH="${SCRIPT_DIR}/ligero-prover/sdk/build/examples/${TARGET_NAME}.wasm"
+WASM_PATH="${SCRIPT_DIR}/ligero-prover/sdk/cpp/build/examples/${TARGET_NAME}.wasm"
 wasm_size=$(stat -f %z "$WASM_PATH" 2>/dev/null || stat -c %s "$WASM_PATH")
 preprocessing_size_bytes=$(( wasm_size ))
 

--- a/ligetron/osx_local_setup.sh
+++ b/ligetron/osx_local_setup.sh
@@ -120,25 +120,13 @@ ok "emsdk ready (emcmake available)"
 # Ligetron submodule
 # -----------------------
 LIGETRON_DIR="${SCRIPT_DIR}/ligero-prover"
-LIGETRON_VERSION="1.4.0"
 
 if [[ ! -d "${LIGETRON_DIR}" ]]; then
   step "Ligetron submodule not found; initializing"
   git -C "${REPO_ROOT}" submodule update --init --recursive ligetron/ligero-prover || {
     warn "Failed to init submodule. Run: git submodule update --init --recursive"; exit 1; }
 fi
-
-# Verify the submodule is at the expected version
-step "Verifying Ligetron submodule version"
-pushd "${LIGETRON_DIR}" >/dev/null
-CURRENT_TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
-if [[ "${CURRENT_TAG}" != "v${LIGETRON_VERSION}" ]]; then
-  warn "Ligetron submodule is at '${CURRENT_TAG:-untagged}', expected 'v${LIGETRON_VERSION}'"
-  warn "Run: git submodule update --init --recursive ligetron/ligero-prover"
-  exit 1
-fi
-popd >/dev/null
-ok "Ligetron submodule at v${LIGETRON_VERSION}"
+ok "Ligetron submodule ready"
 
 # -----------------------
 # Build Ligetron SDK (Web)

--- a/ligetron/osx_local_setup.sh
+++ b/ligetron/osx_local_setup.sh
@@ -24,6 +24,7 @@ if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "This script is for macOS (Darwin) only."; exit 1
 fi
 
+
 REINSTALL=0
 for arg in "$@"; do
   case "$arg" in
@@ -73,7 +74,7 @@ export CXX="${CXX:-clang++}"
 # Build Dawn (WebGPU)
 # -----------------------
 DAWN_DIR="${TP_DIR}/dawn"
-DAWN_COMMIT="41d631c0cbcd46ddc723222fc80890f4305dbc65"
+DAWN_COMMIT="cec4482eccee45696a7c0019e750c77f101ced04"
 
 if [[ ! -d "${DAWN_DIR}" ]]; then
   step "Cloning Dawn"
@@ -149,18 +150,31 @@ ok "emsdk ready (emcmake available)"
 # Ligetron submodule
 # -----------------------
 LIGETRON_DIR="${SCRIPT_DIR}/ligero-prover"
+LIGETRON_VERSION="1.4.0"
+
 if [[ ! -d "${LIGETRON_DIR}" ]]; then
   step "Ligetron submodule not found; initializing"
   git -C "${REPO_ROOT}" submodule update --init --recursive ligetron/ligero-prover || {
     warn "Failed to init submodule. Run: git submodule update --init --recursive"; exit 1; }
 fi
-ok "Ligetron submodule ready"
+
+# Verify the submodule is at the expected version
+step "Verifying Ligetron submodule version"
+pushd "${LIGETRON_DIR}" >/dev/null
+CURRENT_TAG=$(git describe --tags --exact-match 2>/dev/null || echo "")
+if [[ "${CURRENT_TAG}" != "v${LIGETRON_VERSION}" ]]; then
+  warn "Ligetron submodule is at '${CURRENT_TAG:-untagged}', expected 'v${LIGETRON_VERSION}'"
+  warn "Run: git submodule update --init --recursive ligetron/ligero-prover"
+  exit 1
+fi
+popd >/dev/null
+ok "Ligetron submodule at v${LIGETRON_VERSION}"
 
 # -----------------------
 # Build Ligetron SDK (Web)
 # -----------------------
 step "Building Ligetron SDK with emscripten"
-pushd "${LIGETRON_DIR}/sdk" >/dev/null
+pushd "${LIGETRON_DIR}/sdk/cpp" >/dev/null
 if [[ "${REINSTALL}" == "1" ]]; then
   # Clean stale build cache
   rm -rf build

--- a/ligetron/osx_local_setup.sh
+++ b/ligetron/osx_local_setup.sh
@@ -4,9 +4,8 @@ set -euo pipefail
 # ================================
 # Ligetron macOS end-to-end setup
 # ================================
-# - Installs Homebrew deps (cmake, gmp, mpfr, libomp, llvm, boost, nlohmann-json)
+# - Installs Homebrew deps (cmake, gmp, mpfr, libomp, llvm, boost, nlohmann-json, wabt)
 # - Builds Dawn (WebGPU)
-# - Builds WABT
 # - Installs Emscripten (emsdk)
 # - Builds Ligetron SDK (emscripten)
 # - Builds Ligetron native
@@ -23,7 +22,6 @@ warn() { printf "\033[1;33m! %s\033[0m\n" "$*"; }
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "This script is for macOS (Darwin) only."; exit 1
 fi
-
 
 REINSTALL=0
 for arg in "$@"; do
@@ -63,7 +61,7 @@ fi
 
 step "Installing build dependencies via Homebrew"
 brew update
-brew install cmake gmp mpfr libomp llvm boost nlohmann-json
+brew install cmake gmp mpfr libomp llvm boost nlohmann-json wabt
 ok "Homebrew deps installed"
 
 # Prefer Xcode clang; if you want brew llvm, uncomment exports below.
@@ -98,34 +96,6 @@ sudo cmake --install .
 popd >/dev/null
 popd >/dev/null
 ok "Dawn installed"
-
-# -----------------------
-# Build WABT
-# -----------------------
-WABT_DIR="${TP_DIR}/wabt"
-WABT_VERSION="1.0.39"
-if [[ ! -d "${WABT_DIR}" ]]; then
-  step "Cloning WABT"
-  git clone https://github.com/WebAssembly/wabt.git "${WABT_DIR}"
-fi
-
-step "Building & installing WABT @ ${WABT_VERSION} (clang++)"
-pushd "${WABT_DIR}" >/dev/null
-git fetch --all --tags
-git checkout "${WABT_VERSION}"
-git submodule update --init
-if [[ "${REINSTALL}" == "1" ]]; then
-  # Clean stale build cache
-  rm -rf build
-fi
-mkdir -p build
-pushd build >/dev/null
-cmake -DCMAKE_CXX_COMPILER="${CXX}" ..
-cmake --build . -j
-sudo cmake --install .
-popd >/dev/null
-popd >/dev/null
-ok "WABT installed"
 
 # -----------------------
 # Install Emscripten SDK


### PR DESCRIPTION
- Update ligero-prover submodule from v1.0.0 to v1.4.0
- Adjust build to fetch WABT 1.0.39 and cache it with Dawn
- Update Dawn commit to cec4482
- Fix SDK path (sdk → sdk/cpp)
- Update proof output path (proof.data → proof_data.gz)