### PR TITLE
restructure: run stark-v as standalone bench

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -12,7 +12,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  EXCLUDED_CRATES: "nexus cairo-m"
+  EXCLUDED_CRATES: "nexus cairo-m stark-v"
   GITHUB_TOKEN: ${{ secrets.GH_PAT || github.token }}
 
 # ────────────────── 1. Warm‑up build ──────────────────

--- a/.github/workflows/rust_benchmarks_parallel.yml
+++ b/.github/workflows/rust_benchmarks_parallel.yml
@@ -173,6 +173,7 @@ jobs:
             nexus/target
             cairo-m/target
             rookie-numbers/target
+            stark-v/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
@@ -236,6 +237,9 @@ jobs:
           if echo "$CRATES" | grep -q '"rookie-numbers"'; then
             cd rookie-numbers && cargo build --release && cd ..
           fi
+          if echo "$CRATES" | grep -q '"stark-v"'; then
+            cd stark-v && cargo build --release && cd ..
+          fi
 
   bench:
     if: ${{ needs.detect-crates.outputs.crates != '' && needs.detect-crates.outputs.crates != '[]' }}
@@ -264,6 +268,7 @@ jobs:
             nexus/target
             cairo-m/target
             rookie-numbers/target
+            stark-v/target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
@@ -330,7 +335,7 @@ jobs:
           rustup target add riscv64imac-unknown-none-elf
 
       - name: Build and copy excluded memory benchmark binary to workspace target
-        if: ${{ contains(matrix.crate, 'nexus') || contains(matrix.crate, 'cairo-m') || contains(matrix.crate, 'rookie-numbers') }}
+        if: ${{ contains(matrix.crate, 'nexus') || contains(matrix.crate, 'cairo-m') || contains(matrix.crate, 'rookie-numbers') || contains(matrix.crate, 'stark-v') }}
         run: |
           mkdir -p target/release
           if [ "${{ matrix.crate }}" = "nexus" ]; then
@@ -342,6 +347,10 @@ jobs:
           elif [ "${{ matrix.crate }}" = "rookie-numbers" ]; then
             cd rookie-numbers && cargo build --release --bin sha256_mem_rookie_numbers && cd ..
             cp rookie-numbers/target/release/sha256_mem_rookie_numbers target/release/
+          elif [ "${{ matrix.crate }}" = "stark-v" ]; then
+            cd stark-v && cargo build --release --bin sha256_mem_stark_v --bin keccak_mem_stark_v && cd ..
+            cp stark-v/target/release/sha256_mem_stark_v target/release/
+            cp stark-v/target/release/keccak_mem_stark_v target/release/
           fi
 
       - name: Run benches in ${{ matrix.crate }}
@@ -363,7 +372,7 @@ jobs:
           fi
 
       - name: Copy excluded crates criterion results to workspace target
-        if: ${{ contains(matrix.crate, 'nexus') || contains(matrix.crate, 'cairo-m') || contains(matrix.crate, 'rookie-numbers') }}
+        if: ${{ contains(matrix.crate, 'nexus') || contains(matrix.crate, 'cairo-m') || contains(matrix.crate, 'rookie-numbers') || contains(matrix.crate, 'stark-v') }}
         run: |
           mkdir -p target/criterion
           cp -r ${{ matrix.crate }}/target/criterion/* target/criterion/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,9 @@ members = [
     "risc0",
     "sp1",
     "spartan2",
-    "stark-v",
     "utils",
 ]
-exclude = ["cairo-m", "nexus", "rookie-numbers"]
+exclude = ["cairo-m", "nexus", "rookie-numbers", "stark-v"]
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/stark-v/Cargo.toml
+++ b/stark-v/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 [dependencies]
 stark-v-sdk = { git = "https://github.com/AntoineFONDEUR/stark-v", rev = "6cea4701ed6024dbe990573f5fbfd7f7616fd788" }
-bincode = { workspace = true }
+ere-zkvm-interface = { git = "https://github.com/eth-act/ere", rev = "66c516a24d9c3549f76b84f72365ab544299e63a" }
+bincode = "1.3"
+clap = { version = "4.5", features = ["derive", "env"] }
+utils = { path = "../utils" }
 
-# Workspace
-criterion = { workspace = true }
-clap = { workspace = true }
-ere-zkvm-interface = { workspace = true }
-utils = { workspace = true }
+[dev-dependencies]
+criterion = "0.5"
 
 [features]
 default = ["parallel"]

--- a/stark-v/benches/keccak.rs
+++ b/stark-v/benches/keccak.rs
@@ -1,24 +1,21 @@
-use stark_v::stark_v_bench_properties;
 use stark_v::{
-    execution_cycles, prepare_keccak, preprocessing_size, proof_size, prove, verify_keccak,
+    execution_cycles, load_or_compile, prepare_keccak, preprocessing_size, proof_size, prove_bench,
+    stark_v_bench_properties, verify_bench,
 };
-use stark_v_sdk::StarkVCompiler;
 use utils::harness::ProvingSystem;
-use utils::zkvm::helpers::load_or_compile_program;
-use utils::zkvm::KECCAK_BENCH;
 
 utils::define_benchmark_harness!(
-    BenchTarget::Keccak,                                               // target
-    ProvingSystem::StarkV,                                             // system
-    None,                                                              // feature
-    "keccak_mem_stark_v",                                              // mem_binary_name
-    stark_v_bench_properties(),                                        // properties
-    { load_or_compile_program(&StarkVCompiler::new(), KECCAK_BENCH) }, // shared_init
-    prepare_keccak,                                                    // prepare
-    |_, _| 0,           // num_constraints (components.n_constraints())
-    prove,              // prove
-    verify_keccak,      // verify
-    preprocessing_size, // prep_size
-    proof_size,         // proof_size
-    execution_cycles    // execution_cycles
+    BenchTarget::Keccak,
+    ProvingSystem::StarkV,
+    None,
+    "keccak_mem_stark_v",
+    stark_v_bench_properties(),
+    { load_or_compile("keccak") },
+    prepare_keccak,
+    |_, _| 0,
+    |prepared, program| prove_bench(prepared, program),
+    |prepared, proof, program| verify_bench(prepared, proof, program),
+    |prepared, program| preprocessing_size(prepared, program),
+    |proof, program| proof_size(proof, program),
+    execution_cycles
 );

--- a/stark-v/benches/keccak.rs
+++ b/stark-v/benches/keccak.rs
@@ -5,17 +5,17 @@ use stark_v::{
 use utils::harness::ProvingSystem;
 
 utils::define_benchmark_harness!(
-    BenchTarget::Keccak,
-    ProvingSystem::StarkV,
-    None,
-    "keccak_mem_stark_v",
-    stark_v_bench_properties(),
-    { load_or_compile("keccak") },
-    prepare_keccak,
-    |_, _| 0,
-    |prepared, program| prove_bench(prepared, program),
-    |prepared, proof, program| verify_bench(prepared, proof, program),
-    |prepared, program| preprocessing_size(prepared, program),
-    |proof, program| proof_size(proof, program),
-    execution_cycles
+    BenchTarget::Keccak,                                  // target
+    ProvingSystem::StarkV,                                // system
+    None,                                                 // feature
+    "keccak_mem_stark_v",                                 // mem_binary_name
+    stark_v_bench_properties(),                           // properties
+    { load_or_compile("keccak") },                        // shared_init
+    prepare_keccak,                                       // prepare
+    |_, _| 0,                                             // num_constraints
+    |prepared, program| prove_bench(prepared, program),   // prove
+    |prepared, proof, program| verify_bench(prepared, proof, program), // verify
+    |prepared, program| preprocessing_size(prepared, program), // prep_size
+    |proof, program| proof_size(proof, program),          // proof_size
+    execution_cycles                                      // execution_cycles
 );

--- a/stark-v/benches/keccak.rs
+++ b/stark-v/benches/keccak.rs
@@ -5,17 +5,17 @@ use stark_v::{
 use utils::harness::ProvingSystem;
 
 utils::define_benchmark_harness!(
-    BenchTarget::Keccak,                                  // target
-    ProvingSystem::StarkV,                                // system
-    None,                                                 // feature
-    "keccak_mem_stark_v",                                 // mem_binary_name
-    stark_v_bench_properties(),                           // properties
-    { load_or_compile("keccak") },                        // shared_init
-    prepare_keccak,                                       // prepare
-    |_, _| 0,                                             // num_constraints
-    |prepared, program| prove_bench(prepared, program),   // prove
+    BenchTarget::Keccak,                                               // target
+    ProvingSystem::StarkV,                                             // system
+    None,                                                              // feature
+    "keccak_mem_stark_v",                                              // mem_binary_name
+    stark_v_bench_properties(),                                        // properties
+    { load_or_compile("keccak") },                                     // shared_init
+    prepare_keccak,                                                    // prepare
+    |_, _| 0,                                                          // num_constraints
+    |prepared, program| prove_bench(prepared, program),                // prove
     |prepared, proof, program| verify_bench(prepared, proof, program), // verify
-    |prepared, program| preprocessing_size(prepared, program), // prep_size
-    |proof, program| proof_size(proof, program),          // proof_size
-    execution_cycles                                      // execution_cycles
+    |prepared, program| preprocessing_size(prepared, program),         // prep_size
+    |proof, program| proof_size(proof, program),                       // proof_size
+    execution_cycles                                                   // execution_cycles
 );

--- a/stark-v/benches/sha256.rs
+++ b/stark-v/benches/sha256.rs
@@ -5,17 +5,17 @@ use stark_v::{
 use utils::harness::ProvingSystem;
 
 utils::define_benchmark_harness!(
-    BenchTarget::Sha256,
-    ProvingSystem::StarkV,
-    None,
-    "sha256_mem_stark_v",
-    stark_v_bench_properties(),
-    { load_or_compile("sha256") },
-    prepare_sha256,
-    |_, _| 0,
-    |prepared, program| prove_bench(prepared, program),
-    |prepared, proof, program| verify_bench(prepared, proof, program),
-    |prepared, program| preprocessing_size(prepared, program),
-    |proof, program| proof_size(proof, program),
-    execution_cycles
+    BenchTarget::Sha256,                                  // target
+    ProvingSystem::StarkV,                                // system
+    None,                                                 // feature
+    "sha256_mem_stark_v",                                 // mem_binary_name
+    stark_v_bench_properties(),                           // properties
+    { load_or_compile("sha256") },                        // shared_init
+    prepare_sha256,                                       // prepare
+    |_, _| 0,                                             // num_constraints
+    |prepared, program| prove_bench(prepared, program),   // prove
+    |prepared, proof, program| verify_bench(prepared, proof, program), // verify
+    |prepared, program| preprocessing_size(prepared, program), // prep_size
+    |proof, program| proof_size(proof, program),          // proof_size
+    execution_cycles                                      // execution_cycles
 );

--- a/stark-v/benches/sha256.rs
+++ b/stark-v/benches/sha256.rs
@@ -1,24 +1,21 @@
-use stark_v::stark_v_bench_properties;
 use stark_v::{
-    execution_cycles, prepare_sha256, preprocessing_size, proof_size, prove_sha256, verify_sha256,
+    execution_cycles, load_or_compile, prepare_sha256, preprocessing_size, proof_size, prove_bench,
+    stark_v_bench_properties, verify_bench,
 };
-use stark_v_sdk::StarkVCompiler;
 use utils::harness::ProvingSystem;
-use utils::zkvm::helpers::load_or_compile_program;
-use utils::zkvm::SHA256_BENCH;
 
 utils::define_benchmark_harness!(
-    BenchTarget::Sha256,                                               // target
-    ProvingSystem::StarkV,                                             // system
-    None,                                                              // feature
-    "sha256_mem_stark_v",                                              // mem_binary_name
-    stark_v_bench_properties(),                                        // properties
-    { load_or_compile_program(&StarkVCompiler::new(), SHA256_BENCH) }, // shared_init
-    prepare_sha256,                                                    // prepare
-    |_, _| 0,           // num_constraints (components.n_constraints())
-    prove_sha256,       // prove
-    verify_sha256,      // verify
-    preprocessing_size, // prep_size
-    proof_size,         // proof_size
-    execution_cycles    // execution_cycles
+    BenchTarget::Sha256,
+    ProvingSystem::StarkV,
+    None,
+    "sha256_mem_stark_v",
+    stark_v_bench_properties(),
+    { load_or_compile("sha256") },
+    prepare_sha256,
+    |_, _| 0,
+    |prepared, program| prove_bench(prepared, program),
+    |prepared, proof, program| verify_bench(prepared, proof, program),
+    |prepared, program| preprocessing_size(prepared, program),
+    |proof, program| proof_size(proof, program),
+    execution_cycles
 );

--- a/stark-v/benches/sha256.rs
+++ b/stark-v/benches/sha256.rs
@@ -5,17 +5,17 @@ use stark_v::{
 use utils::harness::ProvingSystem;
 
 utils::define_benchmark_harness!(
-    BenchTarget::Sha256,                                  // target
-    ProvingSystem::StarkV,                                // system
-    None,                                                 // feature
-    "sha256_mem_stark_v",                                 // mem_binary_name
-    stark_v_bench_properties(),                           // properties
-    { load_or_compile("sha256") },                        // shared_init
-    prepare_sha256,                                       // prepare
-    |_, _| 0,                                             // num_constraints
-    |prepared, program| prove_bench(prepared, program),   // prove
+    BenchTarget::Sha256,                                               // target
+    ProvingSystem::StarkV,                                             // system
+    None,                                                              // feature
+    "sha256_mem_stark_v",                                              // mem_binary_name
+    stark_v_bench_properties(),                                        // properties
+    { load_or_compile("sha256") },                                     // shared_init
+    prepare_sha256,                                                    // prepare
+    |_, _| 0,                                                          // num_constraints
+    |prepared, program| prove_bench(prepared, program),                // prove
     |prepared, proof, program| verify_bench(prepared, proof, program), // verify
-    |prepared, program| preprocessing_size(prepared, program), // prep_size
-    |proof, program| proof_size(proof, program),          // proof_size
-    execution_cycles                                      // execution_cycles
+    |prepared, program| preprocessing_size(prepared, program),         // prep_size
+    |proof, program| proof_size(proof, program),                       // proof_size
+    execution_cycles                                                   // execution_cycles
 );

--- a/stark-v/src/bin/keccak_mem.rs
+++ b/stark-v/src/bin/keccak_mem.rs
@@ -1,10 +1,7 @@
 //! Memory measurement binary for stark-v Keccak prover.
 
 use clap::Parser;
-use stark_v::{prepare_keccak, prove};
-use stark_v_sdk::StarkVCompiler;
-use utils::zkvm::helpers::load_compiled_program;
-use utils::zkvm::KECCAK_BENCH;
+use stark_v::{load_compiled, prepare_keccak, prove_bench};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -16,7 +13,7 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    let program = load_compiled_program::<StarkVCompiler>(KECCAK_BENCH);
+    let program = load_compiled("keccak");
     let prepared = prepare_keccak(args.input_size, &program);
-    prove(&prepared, &());
+    prove_bench(&prepared, &program);
 }

--- a/stark-v/src/bin/sha256_mem.rs
+++ b/stark-v/src/bin/sha256_mem.rs
@@ -1,10 +1,7 @@
 //! Memory measurement binary for stark-v SHA256 prover.
 
 use clap::Parser;
-use stark_v::{prepare_sha256, prove_sha256};
-use stark_v_sdk::StarkVCompiler;
-use utils::zkvm::helpers::load_compiled_program;
-use utils::zkvm::SHA256_BENCH;
+use stark_v::{load_compiled, prepare_sha256, prove_bench};
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -16,7 +13,7 @@ struct Args {
 fn main() {
     let args = Args::parse();
 
-    let program = load_compiled_program::<StarkVCompiler>(SHA256_BENCH);
+    let program = load_compiled("sha256");
     let prepared = prepare_sha256(args.input_size, &program);
-    prove_sha256(&prepared, &());
+    prove_bench(&prepared, &program);
 }

--- a/stark-v/src/lib.rs
+++ b/stark-v/src/lib.rs
@@ -87,9 +87,10 @@ pub fn load_compiled(bench_name: &str) -> CompiledProgram {
 pub fn prepare_sha256(input_size: usize, program: &CompiledProgram) -> PreparedBench {
     let vm = StarkV::new(program.program.clone());
     let (message_bytes, digest) = utils::generate_sha256_input(input_size);
+    let input = build_prefixed_input(message_bytes);
     PreparedBench {
         vm,
-        input: Input::new().with_prefixed_stdin(message_bytes),
+        input,
         compiled_size: program.byte_size,
         expected_digest: digest,
     }
@@ -98,12 +99,20 @@ pub fn prepare_sha256(input_size: usize, program: &CompiledProgram) -> PreparedB
 pub fn prepare_keccak(input_size: usize, program: &CompiledProgram) -> PreparedBench {
     let vm = StarkV::new(program.program.clone());
     let (message_bytes, digest) = utils::generate_keccak_input(input_size);
+    let input = build_prefixed_input(message_bytes);
     PreparedBench {
         vm,
-        input: Input::new().with_prefixed_stdin(message_bytes),
+        input,
         compiled_size: program.byte_size,
         expected_digest: digest,
     }
+}
+
+/// Build stark-v input with length-prefixed format.
+///
+/// The guest programs expect: [len: u32 LE][data: u8...]
+fn build_prefixed_input(data: Vec<u8>) -> Input {
+    Input::new().with_prefixed_stdin(data)
 }
 
 pub fn prove_bench(prepared: &PreparedBench, _: &CompiledProgram) -> ProofResult {

--- a/stark-v/src/lib.rs
+++ b/stark-v/src/lib.rs
@@ -1,14 +1,28 @@
 //! Stark-V benchmark integration for csp-benchmarks.
 
-use ere_zkvm_interface::Input;
-use stark_v_sdk::{StarkV, StarkVCompiler};
+use bincode::Options;
+use ere_zkvm_interface::{zkVM, Compiler, Input, Proof, ProofKind};
+use stark_v_sdk::{StarkV, StarkVCompiler, StarkVProgram};
+use std::fs;
+use std::path::PathBuf;
 use utils::harness::{AuditStatus, BenchProperties};
-use utils::zkvm::{CompiledProgram, PreparedKeccak, PreparedSha256};
 
-pub use utils::zkvm::{
-    execution_cycles, preprocessing_size, proof_size, prove, prove_sha256, verify_keccak,
-    verify_sha256,
-};
+pub struct CompiledProgram {
+    pub program: StarkVProgram,
+    pub byte_size: usize,
+}
+
+pub struct PreparedBench {
+    vm: StarkV,
+    input: Input,
+    compiled_size: usize,
+    expected_digest: Vec<u8>,
+}
+
+pub struct ProofResult {
+    pub public_values: Vec<u8>,
+    pub proof: Proof,
+}
 
 pub fn stark_v_bench_properties() -> BenchProperties {
     BenchProperties::new(
@@ -27,29 +41,104 @@ pub fn stark_v_bench_properties() -> BenchProperties {
     )
 }
 
-pub fn prepare_sha256(
-    input_size: usize,
-    program: &CompiledProgram<StarkVCompiler>,
-) -> PreparedSha256<StarkV> {
+fn guest_dir(bench_name: &str) -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    PathBuf::from(manifest_dir).join("guest").join(bench_name)
+}
+
+fn compiled_path(bench_name: &str) -> PathBuf {
+    guest_dir(bench_name)
+        .join("target")
+        .join(format!("{}.bin", bench_name))
+}
+
+pub fn load_or_compile(bench_name: &str) -> CompiledProgram {
+    let path = compiled_path(bench_name);
+    if path.exists() {
+        return load_compiled(bench_name);
+    }
+    let compiler = StarkVCompiler::new();
+    let program = compiler
+        .compile(&guest_dir(bench_name))
+        .expect("failed to compile guest program");
+    let bytes = bincode::options()
+        .serialize(&program)
+        .expect("failed to serialize compiled program");
+    fs::create_dir_all(path.parent().unwrap()).expect("failed to create directory");
+    fs::write(&path, &bytes).expect("failed to write compiled program");
+    CompiledProgram {
+        program,
+        byte_size: bytes.len(),
+    }
+}
+
+pub fn load_compiled(bench_name: &str) -> CompiledProgram {
+    let bytes = fs::read(compiled_path(bench_name))
+        .expect("missing compiled guest; the harness should have compiled it already");
+    let program: StarkVProgram = bincode::options()
+        .deserialize(&bytes)
+        .expect("failed to deserialize compiled program");
+    CompiledProgram {
+        program,
+        byte_size: bytes.len(),
+    }
+}
+
+pub fn prepare_sha256(input_size: usize, program: &CompiledProgram) -> PreparedBench {
     let vm = StarkV::new(program.program.clone());
     let (message_bytes, digest) = utils::generate_sha256_input(input_size);
-    let input = build_prefixed_input(message_bytes);
-    PreparedSha256::with_expected_digest(vm, input, program.byte_size, digest)
+    PreparedBench {
+        vm,
+        input: Input::new().with_prefixed_stdin(message_bytes),
+        compiled_size: program.byte_size,
+        expected_digest: digest,
+    }
 }
 
-pub fn prepare_keccak(
-    input_size: usize,
-    program: &CompiledProgram<StarkVCompiler>,
-) -> PreparedKeccak<StarkV> {
+pub fn prepare_keccak(input_size: usize, program: &CompiledProgram) -> PreparedBench {
     let vm = StarkV::new(program.program.clone());
     let (message_bytes, digest) = utils::generate_keccak_input(input_size);
-    let input = build_prefixed_input(message_bytes);
-    PreparedKeccak::with_expected_digest(vm, input, program.byte_size, digest)
+    PreparedBench {
+        vm,
+        input: Input::new().with_prefixed_stdin(message_bytes),
+        compiled_size: program.byte_size,
+        expected_digest: digest,
+    }
 }
 
-/// Build stark-v input with length-prefixed format.
-///
-/// The guest programs expect: [len: u32 LE][data: u8...]
-fn build_prefixed_input(data: Vec<u8>) -> Input {
-    Input::new().with_prefixed_stdin(data)
+pub fn prove_bench(prepared: &PreparedBench, _: &CompiledProgram) -> ProofResult {
+    let (public_values, proof, _) = prepared
+        .vm
+        .prove(&prepared.input, ProofKind::Compressed)
+        .expect("prove failed");
+    ProofResult {
+        public_values,
+        proof,
+    }
+}
+
+pub fn verify_bench(prepared: &PreparedBench, proof: &ProofResult, _: &CompiledProgram) {
+    prepared.vm.verify(&proof.proof).expect("verify failed");
+    assert_eq!(
+        proof.public_values, prepared.expected_digest,
+        "public values do not match expected digest"
+    );
+}
+
+pub fn preprocessing_size(prepared: &PreparedBench, _: &CompiledProgram) -> usize {
+    prepared.compiled_size
+}
+
+pub fn proof_size(proof: &ProofResult, _: &CompiledProgram) -> usize {
+    match &proof.proof {
+        Proof::Compressed(bytes) | Proof::Groth16(bytes) => bytes.len(),
+    }
+}
+
+pub fn execution_cycles(prepared: &PreparedBench) -> u64 {
+    let (_, report) = prepared
+        .vm
+        .execute(&prepared.input)
+        .expect("execute failed");
+    report.total_num_cycles
 }


### PR DESCRIPTION
# Description

When trying to update the pinned `ere` related dependencies commit, it came up that there was a `multiple different versions of crate ere_zkvm_interface in the dependency graph` error when building the project. It can be seen on this run:

- https://github.com/privacy-ethereum/csp-benchmarks/actions/runs/22411363969/job/64885452009?pr=242

`stark-v` crate utilizes the `ere_zkvm_interface` crate to build its own and creates conflicts when updating this crate locally, as it is being included in the workspace calling our `utils` crate which relies on this specific crate as well.

A temporary solution to keep updating `ere` is to exclude `stark-v` and run it as a standalone benchmark.

In a future fix, it could either:

- Get actually itegrated in the `ere` crate.
- Remove `ere_zkvm_interface` dependency and build its own interface without it, or rely on the utils to create it, on our side.