### PR TITLE
fix: restore cwd after guest compilation to fix Jolt RAM measurement

### DIFF
--- a/measure_mem_avg.sh
+++ b/measure_mem_avg.sh
@@ -64,13 +64,26 @@ for i in $(seq 1 $NUM_RUNS); do
   echo " Run #$i..."
   
   # Run the command and capture both program output and measurement output
+  set +e
   output=$({ $TIME_CMD "$@" 2>&1 >/dev/null; } 2>&1)
+  cmd_status=$?
+  set -e
+
+  if (( cmd_status != 0 )); then
+    echo "  Error: benchmark command exited with status $cmd_status" >&2
+    if [[ -n "$output" ]]; then
+      echo "$output" >&2
+    fi
+    exit "$cmd_status"
+  fi
 
   # Locate the memory measurement line
   line=$(echo "$output" | awk -v lab="$MEM_LABEL" 'tolower($0) ~ tolower(lab) {print $0}')
 
   if [[ -z "$line" ]]; then
     echo "  Error: Could not locate memory info in output."
+    echo "  Raw measurement output:"
+    echo "$output"
     exit 1
   fi
 

--- a/utils/src/bench.rs
+++ b/utils/src/bench.rs
@@ -5,7 +5,6 @@ use serde_with::skip_serializing_none;
 use serde_with::{DurationNanoSeconds, serde_as};
 use std::{
     fmt::Display,
-    path::PathBuf,
     process::Command,
     sync::{
         Arc,
@@ -198,20 +197,28 @@ pub fn write_json_metrics_file(output_path: &str, metrics: &Metrics) {
 }
 
 pub fn compile_binary(binary_name: &str) {
-    let _compile_output = Command::new("cargo")
+    let compile_output = Command::new("cargo")
         .arg("build")
         .arg("--release")
         .arg("--bin")
         .arg(binary_name)
         .output()
         .expect("failed to compile");
+
+    assert!(
+        compile_output.status.success(),
+        "failed to compile memory binary '{}'\nstdout:\n{}\nstderr:\n{}",
+        binary_name,
+        String::from_utf8_lossy(&compile_output.stdout),
+        String::from_utf8_lossy(&compile_output.stderr)
+    );
 }
 
 pub fn run_measure_mem_script(json_file: &str, binary_path: &str, input_size: usize) {
-    let script = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../measure_mem_avg.sh");
+    let script = "../measure_mem_avg.sh";
 
-    let output = Command::new("sh")
-        .arg(&script)
+    let output = Command::new("bash")
+        .arg(script)
         .arg("--json")
         .arg(json_file)
         .arg("--")
@@ -229,8 +236,7 @@ pub fn run_measure_mem_script(json_file: &str, binary_path: &str, input_size: us
 
     assert!(
         output.status.success(),
-        "measure_mem_avg.sh ({}) failed with status {:?} for '{}' (input_size={})",
-        script.display(),
+        "measure_mem_avg.sh failed with status {:?} for '{}' (input_size={})",
         output.status.code(),
         binary_path,
         input_size

--- a/utils/src/harness.rs
+++ b/utils/src/harness.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::path::Path;
 use std::str::FromStr;
 
 use crate::bench::{Metrics, compile_binary, run_measure_mem_script, write_json_metrics};
@@ -459,15 +458,7 @@ fn measure_ram(
     size: usize,
 ) {
     compile_binary(mem_bin_name_ref);
-    let candidates = [
-        format!("../target/release/{}", mem_bin_name_ref),
-        format!("target/release/{}", mem_bin_name_ref),
-    ];
-    let bin_path = candidates
-        .iter()
-        .find(|candidate| Path::new(candidate.as_str()).exists())
-        .cloned()
-        .unwrap_or_else(|| candidates[0].clone());
+    let bin_path = format!("../target/release/{}", mem_bin_name_ref);
     let mem_json = mem_report_filename(target_str, size, system_str, cfg.feature);
     run_measure_mem_script(&mem_json, &bin_path, size);
 }

--- a/utils/src/zkvm/helpers.rs
+++ b/utils/src/zkvm/helpers.rs
@@ -96,6 +96,10 @@ pub fn load_compiled_program<C: Compiler>(benchmark_name: &str) -> CompiledProgr
 }
 
 /// Load a compiled program if present, otherwise compile and persist it.
+///
+/// The cwd is saved and restored around compilation because some compiler
+/// implementations (notably Jolt's `RustRv64imacCustomized`) call
+/// `std::env::set_current_dir` and never restore it.
 pub fn load_or_compile_program<C: Compiler>(
     compiler: &C,
     benchmark_name: &str,
@@ -104,8 +108,15 @@ pub fn load_or_compile_program<C: Compiler>(
     if compiled_path.exists() {
         load_compiled_program(benchmark_name)
     } else {
+        let original_dir =
+            std::env::current_dir().expect("failed to get current working directory");
+
         let program = compile_guest_program(compiler, &guest_dir(benchmark_name))
             .expect("failed to compile guest program");
+
+        // Restore cwd in case the compiler changed it.
+        std::env::set_current_dir(&original_dir).expect("failed to restore working directory");
+
         let bytes = bincode::options()
             .serialize(&program.program)
             .expect("failed to serialize compiled program");


### PR DESCRIPTION
Jolt's ere compiler (RustRv64imacCustomized) calls std::env::set_current_dir() to change the process cwd to the guest directory during compilation and never restores it. After load_or_compile_program() returned, all subsequent relative paths (../target/release/<mem_binary>, ../measure_mem_avg.sh) resolved from the wrong directory, causing exit code 127 in CI.

No other zkVM compiler in the ere crate mutates global cwd — they use per-command .current_dir() on Command instead — which is why only Jolt was affected.

Changes:
- Save and restore cwd around compile_guest_program() in helpers.rs
- Assert compile_binary() exit status instead of silently ignoring failures
- Revert previous workarounds (multi-candidate path probing, CARGO_MANIFEST_DIR overrides) that treated symptoms rather than the root cause