### PR TITLE
Adjust Jolt configuration for 2048 B input size of SHA-256

### DIFF
--- a/jolt/guest/ecdsa/Cargo.lock
+++ b/jolt/guest/ecdsa/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 [[package]]
 name = "ere-platform-jolt"
 version = "0.3.0"
-source = "git+https://github.com/0xAndoroid/ere?rev=de078c2#de078c2b525fff6f6c8463df7e7403c8ac414f8b"
+source = "git+https://github.com/eth-act/ere?rev=6573843#65738437e805d6001eeca94b2f40464e41759f64"
 dependencies = [
  "common",
  "ere-platform-trait",
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 name = "ere-platform-trait"
 version = "0.3.0"
-source = "git+https://github.com/0xAndoroid/ere?rev=de078c2#de078c2b525fff6f6c8463df7e7403c8ac414f8b"
+source = "git+https://github.com/eth-act/ere?rev=6573843#65738437e805d6001eeca94b2f40464e41759f64"
 dependencies = [
  "digest",
 ]

--- a/jolt/guest/keccak/Cargo.lock
+++ b/jolt/guest/keccak/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 [[package]]
 name = "ere-platform-jolt"
 version = "0.3.0"
-source = "git+https://github.com/0xAndoroid/ere?rev=de078c2#de078c2b525fff6f6c8463df7e7403c8ac414f8b"
+source = "git+https://github.com/eth-act/ere?rev=6573843#65738437e805d6001eeca94b2f40464e41759f64"
 dependencies = [
  "common",
  "ere-platform-trait",
@@ -164,7 +164,7 @@ dependencies = [
 [[package]]
 name = "ere-platform-trait"
 version = "0.3.0"
-source = "git+https://github.com/0xAndoroid/ere?rev=de078c2#de078c2b525fff6f6c8463df7e7403c8ac414f8b"
+source = "git+https://github.com/eth-act/ere?rev=6573843#65738437e805d6001eeca94b2f40464e41759f64"
 dependencies = [
  "digest",
 ]

--- a/jolt/guest/sha256/Cargo.lock
+++ b/jolt/guest/sha256/Cargo.lock
@@ -153,6 +153,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 [[package]]
 name = "ere-platform-jolt"
 version = "0.3.0"
+source = "git+https://github.com/eth-act/ere?rev=6573843#65738437e805d6001eeca94b2f40464e41759f64"
 dependencies = [
  "common",
  "ere-platform-trait",
@@ -163,6 +164,7 @@ dependencies = [
 [[package]]
 name = "ere-platform-trait"
 version = "0.3.0"
+source = "git+https://github.com/eth-act/ere?rev=6573843#65738437e805d6001eeca94b2f40464e41759f64"
 dependencies = [
  "digest",
 ]

--- a/jolt/src/lib.rs
+++ b/jolt/src/lib.rs
@@ -50,7 +50,8 @@ pub fn prepare_sha256(
     input_size: usize,
     program: &CompiledProgram<RustRv64imacCustomized>,
 ) -> PreparedSha256<EreJolt> {
-    set_jolt_config(65536, 4096, 32768);
+    let max_trace_length = if input_size > 1024 { 131072 } else { 65536 };
+    set_jolt_config(max_trace_length, 4096, 32768);
     let vm = EreJolt::new(program.program.clone(), ProverResource::Cpu)
         .expect("jolt prover build failed");
 


### PR DESCRIPTION
The max trace length of 65536 was insufficient for running the SHA-256 circuit benchmark with 2048 B input (see error log:
https://github.com/privacy-ethereum/csp-benchmarks/actions/runs/23023028374/job/66948508069). We set the max trace size for 2kB input to 131072 to accommodate.