### PR TITLE
fix: pin WABT to 1.0.39 for Ligetron

### DIFF
--- a/.github/actions/install-ligero/action.yml
+++ b/.github/actions/install-ligero/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: cec4482eccee45696a7c0019e750c77f101ced04
   install_prefix:
-    description: Where to install Dawn/WABT (used as CMAKE_PREFIX_PATH).
+    description: Where to install Dawn (used as CMAKE_PREFIX_PATH).
     required: false
     default: ${{ github.workspace }}/.deps/install
 
@@ -46,7 +46,7 @@ runs:
       run: |
         set -euo pipefail
         NEEDS=()
-        for pkg in cmake ninja gmp mpfr libomp llvm boost nlohmann-json ccache wabt; do
+        for pkg in cmake ninja gmp mpfr libomp llvm boost nlohmann-json ccache; do
           brew list --versions "$pkg" >/dev/null 2>&1 || NEEDS+=("$pkg")
         done
         if [[ ${#NEEDS[@]} -gt 0 ]]; then

--- a/.github/actions/install-wabt/action.yml
+++ b/.github/actions/install-wabt/action.yml
@@ -1,0 +1,51 @@
+name: "Install WABT"
+description: "Installs a pinned version of the WebAssembly Binary Toolkit (WABT)"
+
+inputs:
+  version:
+    description: WABT version to install.
+    required: false
+    default: "1.0.39"
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        VERSION="${{ inputs.version }}"
+        INSTALL_DIR="$HOME/.wabt"
+
+        if [[ -x "$INSTALL_DIR/bin/wat2wasm" ]] && \
+           [[ "$("$INSTALL_DIR/bin/wat2wasm" --version 2>/dev/null)" == "$VERSION" ]]; then
+          echo "WABT $VERSION already installed"
+          echo "$INSTALL_DIR/bin" >> "$GITHUB_PATH"
+          exit 0
+        fi
+
+        ARCH="$(uname -m)"
+        OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+        USE_BREW_FALLBACK=0
+        case "${OS}-${ARCH}" in
+          darwin-arm64) ASSET="wabt-${VERSION}-macos-arm64.tar.gz" ;;
+          darwin-x86_64) USE_BREW_FALLBACK=1 ;;
+          linux-x86_64) ASSET="wabt-${VERSION}-linux-x64.tar.gz" ;;
+          linux-aarch64) ASSET="wabt-${VERSION}-linux-arm64.tar.gz" ;;
+          *) echo "Unsupported platform: ${OS}-${ARCH}" >&2; exit 1 ;;
+        esac
+
+        if [[ "$USE_BREW_FALLBACK" == "1" ]]; then
+          echo "No pinned WABT binary asset for ${OS}-${ARCH}; falling back to Homebrew wabt"
+          brew list --versions wabt >/dev/null 2>&1 || { brew update; brew install wabt; }
+          BREW_PREFIX="$(brew --prefix wabt)"
+          echo "$BREW_PREFIX/bin" >> "$GITHUB_PATH"
+          exit 0
+        fi
+
+        URL="https://github.com/WebAssembly/wabt/releases/download/${VERSION}/${ASSET}"
+        echo "Installing WABT ${VERSION} from ${URL}"
+        rm -rf "$INSTALL_DIR"
+        mkdir -p "$INSTALL_DIR"
+        curl -fsSL "$URL" | tar -xz --strip-components=1 -C "$INSTALL_DIR"
+
+        echo "$INSTALL_DIR/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/sh_benchmarks_parallel.yml
+++ b/.github/workflows/sh_benchmarks_parallel.yml
@@ -118,6 +118,10 @@ jobs:
         run: |
           brew install bash
 
+      - name: Install pinned WABT (only when folder is ligetron)
+        if: ${{ matrix.folder == 'ligetron' }}
+        uses: ./.github/actions/install-wabt
+
       - name: Setup & build Ligetron (only when folder is ligetron)
         if: ${{ matrix.folder == 'ligetron' }}
         uses: ./.github/actions/install-ligero

--- a/ligetron/osx_local_setup.sh
+++ b/ligetron/osx_local_setup.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 # ================================
 # Ligetron macOS end-to-end setup
 # ================================
-# - Installs Homebrew deps (cmake, gmp, mpfr, libomp, llvm, boost, nlohmann-json, wabt)
+# - Installs Homebrew deps (cmake, gmp, mpfr, libomp, llvm, boost, nlohmann-json)
+# - Installs pinned WABT release (1.0.39) on macOS arm64
 # - Builds Dawn (WebGPU)
 # - Installs Emscripten (emsdk)
 # - Builds Ligetron SDK (emscripten)
@@ -42,6 +43,7 @@ ROOT_DIR="$(pwd)"
 TP_DIR="${ROOT_DIR}/third_party"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+WABT_VERSION="1.0.39"
 mkdir -p "${TP_DIR}"
 
 if [[ "${REINSTALL}" == "1" ]]; then
@@ -61,8 +63,28 @@ fi
 
 step "Installing build dependencies via Homebrew"
 brew update
-brew install cmake gmp mpfr libomp llvm boost nlohmann-json wabt
+brew install cmake gmp mpfr libomp llvm boost nlohmann-json
 ok "Homebrew deps installed"
+
+step "Installing pinned WABT ${WABT_VERSION}"
+ARCH="$(uname -m)"
+if [[ "$ARCH" == "arm64" ]]; then
+  WABT_DIR="${TP_DIR}/wabt-${WABT_VERSION}"
+  if [[ ! -x "${WABT_DIR}/bin/wat2wasm" ]] || [[ "$("${WABT_DIR}/bin/wat2wasm" --version 2>/dev/null || true)" != "${WABT_VERSION}" ]]; then
+    TMPDIR="$(mktemp -d)"
+    trap 'rm -rf "$TMPDIR"' EXIT
+    URL="https://github.com/WebAssembly/wabt/releases/download/${WABT_VERSION}/wabt-${WABT_VERSION}-macos-arm64.tar.gz"
+    curl -fsSL "$URL" -o "$TMPDIR/wabt.tar.gz"
+    rm -rf "${WABT_DIR}"
+    mkdir -p "${WABT_DIR}"
+    tar -xzf "$TMPDIR/wabt.tar.gz" --strip-components=1 -C "${WABT_DIR}"
+  fi
+  export PATH="${WABT_DIR}/bin:${PATH}"
+  ok "Pinned WABT installed (${WABT_VERSION})"
+else
+  warn "No pinned macOS WABT binary for architecture '${ARCH}'. Falling back to Homebrew wabt."
+  brew list --versions wabt >/dev/null 2>&1 || brew install wabt
+fi
 
 # Prefer Xcode clang; if you want brew llvm, uncomment exports below.
 export CC="${CC:-clang}"
@@ -121,18 +143,47 @@ ok "emsdk ready (emcmake available)"
 # -----------------------
 LIGETRON_DIR="${SCRIPT_DIR}/ligero-prover"
 
-if [[ ! -d "${LIGETRON_DIR}" ]]; then
-  step "Ligetron submodule not found; initializing"
+if [[ ! -f "${LIGETRON_DIR}/CMakeLists.txt" ]]; then
+  step "Ligetron submodule missing or incomplete; initializing/updating"
   git -C "${REPO_ROOT}" submodule update --init --recursive ligetron/ligero-prover || {
     warn "Failed to init submodule. Run: git submodule update --init --recursive"; exit 1; }
 fi
-ok "Ligetron submodule ready"
+
+if [[ ! -f "${LIGETRON_DIR}/CMakeLists.txt" ]]; then
+  warn "Ligetron submodule still missing expected files at ${LIGETRON_DIR}."
+  warn "Run: git -C ${REPO_ROOT} submodule update --init --recursive ligetron/ligero-prover"
+  exit 1
+fi
+
+SDK_DIR=""
+if [[ -f "${LIGETRON_DIR}/sdk/cpp/CMakeLists.txt" ]]; then
+  SDK_DIR="${LIGETRON_DIR}/sdk/cpp"
+elif [[ -f "${LIGETRON_DIR}/sdk/CMakeLists.txt" ]]; then
+  SDK_DIR="${LIGETRON_DIR}/sdk"
+elif [[ -f "${LIGETRON_DIR}/cpp/CMakeLists.txt" ]]; then
+  SDK_DIR="${LIGETRON_DIR}/cpp"
+else
+  warn "Could not find Ligetron SDK CMakeLists.txt (tried sdk/cpp, sdk, cpp)."
+  exit 1
+fi
+
+NATIVE_DIR=""
+if [[ -f "${LIGETRON_DIR}/CMakeLists.txt" ]]; then
+  NATIVE_DIR="${LIGETRON_DIR}"
+elif [[ -f "${LIGETRON_DIR}/native/CMakeLists.txt" ]]; then
+  NATIVE_DIR="${LIGETRON_DIR}/native"
+else
+  warn "Could not find Ligetron native CMakeLists.txt."
+  exit 1
+fi
+
+ok "Ligetron submodule ready (sdk=${SDK_DIR}, native=${NATIVE_DIR})"
 
 # -----------------------
 # Build Ligetron SDK (Web)
 # -----------------------
 step "Building Ligetron SDK with emscripten"
-pushd "${LIGETRON_DIR}/sdk/cpp" >/dev/null
+pushd "${SDK_DIR}" >/dev/null
 if [[ "${REINSTALL}" == "1" ]]; then
   # Clean stale build cache
   rm -rf build
@@ -152,7 +203,7 @@ ok "Ligetron SDK built"
 # Build Ligetron Native
 # -----------------------
 step "Building Ligetron native (Release)"
-pushd "${LIGETRON_DIR}" >/dev/null
+pushd "${NATIVE_DIR}" >/dev/null
 if [[ "${REINSTALL}" == "1" ]]; then
   # Clean stale build cache
   rm -rf build


### PR DESCRIPTION
The latest Ligetron build failed due to WABT 1.0.40: https://github.com/privacy-ethereum/csp-benchmarks/actions/runs/22975346067/job/66702775044
The previous successful build used WABT 1.0.39: https://github.com/privacy-ethereum/csp-benchmarks/actions/runs/22975346067/job/66702775044

Reported upstream: https://github.com/ligeroinc/ligero-prover/issues/8