### PR TITLE
chore(stark-v): update to ClementWalter/stark-v at 5a2e9d6

### DIFF
--- a/stark-v/Cargo.lock
+++ b/stark-v/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
 [[package]]
 name = "debug-utils"
 version = "0.0.1"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "comfy-table",
  "stwo",
@@ -1033,6 +1033,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ere-zkvm-interface"
+version = "0.3.0"
+source = "git+https://github.com/eth-act/ere?rev=6573843#65738437e805d6001eeca94b2f40464e41759f64"
+dependencies = [
+ "anyhow",
+ "auto_impl",
+ "bincode 2.0.1",
+ "indexmap 2.13.0",
+ "serde",
+ "strum",
+ "thiserror",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,9 +1080,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.2.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -1125,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "guest-lib"
 version = "0.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "k256",
  "postcard",
@@ -1173,6 +1187,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -1180,13 +1197,6 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "heapless"
@@ -1668,7 +1678,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "bytemuck",
  "debug-utils",
@@ -1820,7 +1830,7 @@ dependencies = [
 [[package]]
 name = "runner"
 version = "0.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "clap",
  "debug-utils",
@@ -2082,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "simd"
 version = "0.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "stwo",
 ]
@@ -2125,7 +2135,7 @@ dependencies = [
  "bincode 1.3.3",
  "clap",
  "criterion",
- "ere-zkvm-interface",
+ "ere-zkvm-interface 0.2.0",
  "stark-v-sdk",
  "utils",
 ]
@@ -2133,11 +2143,11 @@ dependencies = [
 [[package]]
 name = "stark-v-sdk"
 version = "0.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "anyhow",
  "cargo_metadata",
- "ere-zkvm-interface",
+ "ere-zkvm-interface 0.2.0",
  "guest-lib",
  "postcard",
  "prover",
@@ -2204,7 +2214,7 @@ dependencies = [
 [[package]]
 name = "std-shims"
 version = "1.0.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 
 [[package]]
 name = "strsim"
@@ -2236,7 +2246,7 @@ dependencies = [
 [[package]]
 name = "stwo"
 version = "2.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "blake2",
  "blake3",
@@ -2245,7 +2255,7 @@ dependencies = [
  "dashmap",
  "educe 0.5.11",
  "fnv",
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
  "hex",
  "indexmap 2.13.0",
  "itertools 0.13.0",
@@ -2265,9 +2275,9 @@ dependencies = [
 [[package]]
 name = "stwo-constraint-framework"
 version = "2.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.15.5",
  "itertools 0.13.0",
  "num-traits",
  "rand",
@@ -2280,7 +2290,7 @@ dependencies = [
 [[package]]
 name = "stwo-macros"
 version = "0.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2296,7 +2306,7 @@ checksum = "5c21e2c707fb8926e6c4355a87494c29e8e46640ff4796aa8fbb74952327dfdc"
 [[package]]
 name = "stwo-types"
 version = "2.0.1"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "bytemuck",
  "num-traits",
@@ -2565,7 +2575,7 @@ dependencies = [
  "clap",
  "criterion",
  "csv",
- "ere-zkvm-interface",
+ "ere-zkvm-interface 0.3.0",
  "glob",
  "hex",
  "human-repr",

--- a/stark-v/Cargo.lock
+++ b/stark-v/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 [[package]]
 name = "debug-utils"
 version = "0.0.1"
-source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
+source = "git+https://github.com/ClementWalter/stark-v?rev=0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1#0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1"
 dependencies = [
  "comfy-table",
  "stwo",
@@ -1138,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "guest-lib"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
+source = "git+https://github.com/ClementWalter/stark-v?rev=0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1#0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1"
 dependencies = [
  "k256",
  "postcard",
@@ -1681,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
+source = "git+https://github.com/ClementWalter/stark-v?rev=0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1#0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1"
 dependencies = [
  "bytemuck",
  "debug-utils",
@@ -1833,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "runner"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
+source = "git+https://github.com/ClementWalter/stark-v?rev=0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1#0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1"
 dependencies = [
  "clap",
  "debug-utils",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "simd"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
+source = "git+https://github.com/ClementWalter/stark-v?rev=0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1#0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1"
 dependencies = [
  "stwo",
 ]
@@ -2146,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "stark-v-sdk"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
+source = "git+https://github.com/ClementWalter/stark-v?rev=0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1#0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2215,11 +2215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "std-shims"
-version = "1.0.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "stwo"
 version = "2.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
+source = "git+https://github.com/ClementWalter/stark-v?rev=0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1#0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1"
 dependencies = [
  "blake2",
  "blake3",
@@ -2269,7 +2264,6 @@ dependencies = [
  "starknet-crypto",
  "starknet-ff",
  "stwo-std-shims",
- "stwo-types",
  "thiserror",
  "tracing",
  "tracing-subscriber",
@@ -2278,7 +2272,7 @@ dependencies = [
 [[package]]
 name = "stwo-constraint-framework"
 version = "2.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
+source = "git+https://github.com/ClementWalter/stark-v?rev=0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1#0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1"
 dependencies = [
  "hashbrown 0.16.1",
  "itertools 0.13.0",
@@ -2293,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "stwo-macros"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
+source = "git+https://github.com/ClementWalter/stark-v?rev=0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1#0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2305,19 +2299,6 @@ name = "stwo-std-shims"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c21e2c707fb8926e6c4355a87494c29e8e46640ff4796aa8fbb74952327dfdc"
-
-[[package]]
-name = "stwo-types"
-version = "2.0.1"
-source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
-dependencies = [
- "bytemuck",
- "num-traits",
- "rand",
- "rayon",
- "serde",
- "std-shims",
-]
 
 [[package]]
 name = "subtle"

--- a/stark-v/Cargo.lock
+++ b/stark-v/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -61,15 +61,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -491,9 +491,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -548,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -558,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "comfy-table"
@@ -780,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -790,11 +790,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -804,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -830,7 +829,7 @@ dependencies = [
 [[package]]
 name = "debug-utils"
 version = "0.0.1"
-source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
+source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
 dependencies = [
  "comfy-table",
  "stwo",
@@ -993,18 +992,18 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1080,9 +1079,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "generic-array"
@@ -1139,7 +1138,7 @@ dependencies = [
 [[package]]
 name = "guest-lib"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
+source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
 dependencies = [
  "k256",
  "postcard",
@@ -1187,9 +1186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
- "equivalent",
- "foldhash",
- "serde",
 ]
 
 [[package]]
@@ -1197,6 +1193,13 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "heapless"
@@ -1342,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
@@ -1454,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1478,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1678,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
+source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
 dependencies = [
  "bytemuck",
  "debug-utils",
@@ -1830,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "runner"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
+source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
 dependencies = [
  "clap",
  "debug-utils",
@@ -2014,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64",
  "chrono",
@@ -2033,9 +2036,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2092,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "simd"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
+source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
 dependencies = [
  "stwo",
 ]
@@ -2143,7 +2146,7 @@ dependencies = [
 [[package]]
 name = "stark-v-sdk"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
+source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -2214,7 +2217,7 @@ dependencies = [
 [[package]]
 name = "std-shims"
 version = "1.0.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
+source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
 
 [[package]]
 name = "strsim"
@@ -2246,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "stwo"
 version = "2.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
+source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
 dependencies = [
  "blake2",
  "blake3",
@@ -2255,7 +2258,7 @@ dependencies = [
  "dashmap",
  "educe 0.5.11",
  "fnv",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hex",
  "indexmap 2.13.0",
  "itertools 0.13.0",
@@ -2275,9 +2278,9 @@ dependencies = [
 [[package]]
 name = "stwo-constraint-framework"
 version = "2.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
+source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "itertools 0.13.0",
  "num-traits",
  "rand",
@@ -2290,7 +2293,7 @@ dependencies = [
 [[package]]
 name = "stwo-macros"
 version = "0.1.0"
-source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
+source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2306,7 +2309,7 @@ checksum = "5c21e2c707fb8926e6c4355a87494c29e8e46640ff4796aa8fbb74952327dfdc"
 [[package]]
 name = "stwo-types"
 version = "2.0.1"
-source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
+source = "git+https://github.com/ClementWalter/stark-v?rev=1409577f7716551b6c97fab2d8a9d042421351f1#1409577f7716551b6c97fab2d8a9d042421351f1"
 dependencies = [
  "bytemuck",
  "num-traits",
@@ -2505,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2535,9 +2538,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
 
 [[package]]
 name = "unicode-width"
@@ -2777,18 +2780,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.41"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.41"
+version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/stark-v/Cargo.toml
+++ b/stark-v/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-stark-v-sdk = { git = "https://github.com/ClementWalter/stark-v", rev = "5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57" }
+stark-v-sdk = { git = "https://github.com/ClementWalter/stark-v", rev = "1409577f7716551b6c97fab2d8a9d042421351f1" }
 ere-zkvm-interface = { git = "https://github.com/eth-act/ere", rev = "66c516a24d9c3549f76b84f72365ab544299e63a" }
 bincode = "1.3"
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/stark-v/Cargo.toml
+++ b/stark-v/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-stark-v-sdk = { git = "https://github.com/ClementWalter/stark-v", rev = "1409577f7716551b6c97fab2d8a9d042421351f1" }
+stark-v-sdk = { git = "https://github.com/ClementWalter/stark-v", rev = "0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1" }
 ere-zkvm-interface = { git = "https://github.com/eth-act/ere", rev = "66c516a24d9c3549f76b84f72365ab544299e63a" }
 bincode = "1.3"
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/stark-v/Cargo.toml
+++ b/stark-v/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-stark-v-sdk = { git = "https://github.com/AntoineFONDEUR/stark-v", rev = "3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef" }
+stark-v-sdk = { git = "https://github.com/ClementWalter/stark-v", rev = "5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57" }
 ere-zkvm-interface = { git = "https://github.com/eth-act/ere", rev = "66c516a24d9c3549f76b84f72365ab544299e63a" }
 bincode = "1.3"
 clap = { version = "4.5", features = ["derive", "env"] }

--- a/stark-v/guest/keccak/Cargo.lock
+++ b/stark-v/guest/keccak/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "guest-bin"
 version = "0.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "guest-lib",
  "postcard",
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 name = "guest-lib"
 version = "0.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "k256",
  "postcard",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "lock_api"
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]

--- a/stark-v/guest/keccak/Cargo.toml
+++ b/stark-v/guest/keccak/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-guest-bin = { git = "https://github.com/AntoineFONDEUR/stark-v", rev = "3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef" }
-guest-lib = { git = "https://github.com/AntoineFONDEUR/stark-v", rev = "3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef" }
+guest-bin = { git = "https://github.com/ClementWalter/stark-v", rev = "5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57" }
+guest-lib = { git = "https://github.com/ClementWalter/stark-v", rev = "5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57" }
 sha3 = { version = "0.10", default-features = false }
 
 [workspace]

--- a/stark-v/guest/sha256/Cargo.lock
+++ b/stark-v/guest/sha256/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "guest-bin"
 version = "0.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "guest-lib",
  "postcard",
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 name = "guest-lib"
 version = "0.1.0"
-source = "git+https://github.com/AntoineFONDEUR/stark-v?rev=3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef#3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef"
+source = "git+https://github.com/ClementWalter/stark-v?rev=5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57#5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57"
 dependencies = [
  "k256",
  "postcard",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "lock_api"
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]

--- a/stark-v/guest/sha256/Cargo.toml
+++ b/stark-v/guest/sha256/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-guest-bin = { git = "https://github.com/AntoineFONDEUR/stark-v", rev = "3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef" }
-guest-lib = { git = "https://github.com/AntoineFONDEUR/stark-v", rev = "3a3cb4cf576d7d7e8ca82815acfb31bbc10e48ef" }
+guest-bin = { git = "https://github.com/ClementWalter/stark-v", rev = "5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57" }
+guest-lib = { git = "https://github.com/ClementWalter/stark-v", rev = "5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57" }
 sha2 = { version = "0.10", default-features = false }
 
 [workspace]

--- a/stark-v/src/lib.rs
+++ b/stark-v/src/lib.rs
@@ -33,7 +33,7 @@ pub fn stark_v_bench_properties() -> BenchProperties {
         "AIR",
         false,                   // Not ZK
         true,                    // zkVM
-        94, // https://github.com/ClementWalter/stark-v/blob/1409577f7716551b6c97fab2d8a9d042421351f1/crates/sdk/src/lib.rs#L56 — batching caps at 94 bits for trace ≤ 2^20
+        94, // https://github.com/ClementWalter/stark-v/blob/0bf633bc5a87b14d2e2ad4d8f30be2701849e0c1/crates/sdk/src/lib.rs#L56 — batching caps at 94 bits for trace ≤ 2^20
         true, // hash-based PCS
         true, // not actively maintained
         AuditStatus::NotAudited, // https://github.com/kkrt-labs/cairo-m/?tab=readme-ov-file#about

--- a/stark-v/src/lib.rs
+++ b/stark-v/src/lib.rs
@@ -33,7 +33,7 @@ pub fn stark_v_bench_properties() -> BenchProperties {
         "AIR",
         false,                   // Not ZK
         true,                    // zkVM
-        96, // https://github.com/AntoineFONDEUR/stark-v/blob/740812dfb29bfd05e24c9e8b1ad6b211ac1b564e/crates/sdk/src/lib.rs#L57
+        96, // https://github.com/ClementWalter/stark-v/blob/5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57/crates/sdk/src/lib.rs#L57
         true, // hash-based PCS
         true, // not actively maintained
         AuditStatus::NotAudited, // https://github.com/kkrt-labs/cairo-m/?tab=readme-ov-file#about

--- a/stark-v/src/lib.rs
+++ b/stark-v/src/lib.rs
@@ -33,7 +33,7 @@ pub fn stark_v_bench_properties() -> BenchProperties {
         "AIR",
         false,                   // Not ZK
         true,                    // zkVM
-        96, // https://github.com/ClementWalter/stark-v/blob/5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57/crates/sdk/src/lib.rs#L57
+        94, // https://github.com/ClementWalter/stark-v/blob/5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57/crates/sdk/src/lib.rs#L57 — batching caps at 94 bits for trace ≤ 2^20
         true, // hash-based PCS
         true, // not actively maintained
         AuditStatus::NotAudited, // https://github.com/kkrt-labs/cairo-m/?tab=readme-ov-file#about

--- a/stark-v/src/lib.rs
+++ b/stark-v/src/lib.rs
@@ -33,7 +33,7 @@ pub fn stark_v_bench_properties() -> BenchProperties {
         "AIR",
         false,                   // Not ZK
         true,                    // zkVM
-        94, // https://github.com/ClementWalter/stark-v/blob/5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57/crates/sdk/src/lib.rs#L57 — batching caps at 94 bits for trace ≤ 2^20
+        94, // https://github.com/ClementWalter/stark-v/blob/1409577f7716551b6c97fab2d8a9d042421351f1/crates/sdk/src/lib.rs#L56 — batching caps at 94 bits for trace ≤ 2^20
         true, // hash-based PCS
         true, // not actively maintained
         AuditStatus::NotAudited, // https://github.com/kkrt-labs/cairo-m/?tab=readme-ov-file#about


### PR DESCRIPTION
## Summary
- Update stark-v git dependency from `AntoineFONDEUR/stark-v` to `ClementWalter/stark-v` (repo ownership change)
- Bump revision to `5a2e9d6e888fc8953bf50b59aeb3d8bcdc0d9d57` (latest main)
- Regenerate all Cargo.lock files (host, guest/sha256, guest/keccak)

## Test plan
- [ ] `cargo check` passes in `stark-v/` directory
- [ ] CI benchmarks pass for stark-v