### PR TITLE
chore(noir): update noir version and use optimized poseidon2 library

### DIFF
--- a/.github/actions/install-nargo/action.yml
+++ b/.github/actions/install-nargo/action.yml
@@ -5,14 +5,12 @@ inputs:
   version:
     description: Version of Nargo/Noir binaries.
     required: false
-    default: "1.0.0-beta.13"
+    default: "1.0.0-beta.19"
 
 runs:
   using: "composite"
   steps:
-    - shell: bash
-      run: |
-        curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
-        export PATH="$HOME/.nargo/bin:$PATH"
-        ~/.nargo/bin/noirup --version ${{ inputs.version }}
-        echo "$HOME/.nargo/bin" >> $GITHUB_PATH
+    - name: Install Nargo
+      uses: noir-lang/noirup@v0.1.4
+      with:
+        toolchain: ${{ inputs.version }}

--- a/.github/workflows/sh_benchmarks_parallel.yml
+++ b/.github/workflows/sh_benchmarks_parallel.yml
@@ -132,8 +132,6 @@ jobs:
       - name: Setup Nargo (only when folder is barretenberg)
         if: ${{ matrix.folder == 'barretenberg' }}
         uses: ./.github/actions/install-nargo
-        with:
-          version: "1.0.0-beta.13"
 
       - name: Setup Barretenberg (only when folder is barretenberg)
         if: ${{ matrix.folder == 'barretenberg' }}

--- a/barretenberg/README.md
+++ b/barretenberg/README.md
@@ -15,7 +15,7 @@ Match the CI setup from `.github/workflows/sh_benchmarks_parallel.yml` and the h
    ```bash
    curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
    export PATH="$HOME/.nargo/bin:$PATH"
-   ~/.nargo/bin/noirup --version 1.0.0-beta.13
+   ~/.nargo/bin/noirup --version 1.0.0-beta.19
    ```
 
 2. **Install the Barretenberg CLI**
@@ -23,7 +23,7 @@ Match the CI setup from `.github/workflows/sh_benchmarks_parallel.yml` and the h
    ```bash
    curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
    export PATH="$HOME/.bb:$PATH"
-   bbup -v 1.2.0
+   bbup -v 5.0.0-nightly.20260324
    ```
 
 ## Installation & Test Run

--- a/barretenberg/circuits/hash/poseidon2/Nargo.toml
+++ b/barretenberg/circuits/hash/poseidon2/Nargo.toml
@@ -4,4 +4,4 @@ type = "bin"
 compiler_version = ">=1.0.0"
 
 [dependencies]
-poseidon2 = { tag = "v0.5.0-beta.0", git = "https://github.com/TaceoLabs/noir-poseidon", directory = "poseidon2" }
+poseidon = { tag = "v0.2.6", git = "https://github.com/noir-lang/poseidon" }

--- a/barretenberg/circuits/hash/poseidon2/src/main.nr
+++ b/barretenberg/circuits/hash/poseidon2/src/main.nr
@@ -1,5 +1,5 @@
-use poseidon2::bn254::hash_2;
+use poseidon::poseidon2::Poseidon2;
 
 fn main(inputs: [Field; 2]) -> pub Field {
-    hash_2(inputs)
+    Poseidon2::hash(inputs, 2)
 }

--- a/barretenberg/osx_local_setup.sh
+++ b/barretenberg/osx_local_setup.sh
@@ -44,8 +44,8 @@ else
     fi
 fi
 
-step "Installing Noir v1.0.0-beta.13"
-noirup --version 1.0.0-beta.13
+step "Installing Noir v1.0.0-beta.19"
+noirup --version 1.0.0-beta.19
 
 # -----------------------
 # Install Barretenberg(bbup)
@@ -72,8 +72,8 @@ else
     fi
 fi
 
-step "Installing Barretenberg v1.2.0"
-bbup -v 1.2.0
+step "Installing Barretenberg v5.0.0-nightly.20260324"
+bbup -v 5.0.0-nightly.20260324
 
 # -----------------------
 # Run demo prover & verifier

--- a/barretenberg/poseidon2_prepare.sh
+++ b/barretenberg/poseidon2_prepare.sh
@@ -11,10 +11,10 @@ WORKSPACE_ROOT_PATH="${SCRIPT_DIR}/circuits"
 # Update circuit to use INPUT_SIZE
 CIRCUIT_SOURCE="${WORKSPACE_ROOT_PATH}/hash/poseidon2/src/main.nr"
 if [[ -f "$CIRCUIT_SOURCE" ]]; then
-  # Replace hash_N function name and array size
+  # Replace array size and hash length argument for INPUT_SIZE
   sed -E -i.bak \
-    -e "s/hash_[0-9]+/hash_${INPUT_SIZE}/g" \
     -e "s/\[Field;[[:space:]]*[0-9]+\]/[Field; ${INPUT_SIZE}]/g" \
+    -e "s/Poseidon2::hash\(inputs,[[:space:]]*[0-9]+\)/Poseidon2::hash(inputs, ${INPUT_SIZE})/g" \
     "$CIRCUIT_SOURCE"
   rm -f "${CIRCUIT_SOURCE}.bak"
 else


### PR DESCRIPTION
This PR bundles 3 changes to the noir benchmarks:

- They're now run under nargo 1.0.0-beta.19 and Barretenberg v5.0.0-nightly.20260324.
- The `install-nargo` action now delegates to the official `noirup` action (I've maintained the `install-nargo` action for consistency but it can be removed)
-  The  `poseidon2` benchmark has been updated to use the official [poseidon library](https://github.com/noir-lang/poseidon) which exposes both poseidon and poseidon2. I've swapped this out as the official library makes use of a more optimized implementation of poseidon2.