### PR TITLE
(draft) feat: add zolt-bench crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16159,6 +16159,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
+name = "zolt-bench"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "criterion",
+ "utils 0.1.0",
+]
+
+[[package]]
 name = "zstd"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "sp1",
     "spartan2",
     "utils",
+    "zolt-bench",
 ]
 exclude = ["cairo-m", "nexus", "rookie-numbers", "stark-v"]
 

--- a/utils/src/harness.rs
+++ b/utils/src/harness.rs
@@ -60,6 +60,7 @@ pub enum ProvingSystem {
     Spartan2,
     RookieNumbers,
     StarkV,
+    Zolt,
     // Extend as needed
 }
 
@@ -81,6 +82,7 @@ impl ProvingSystem {
             ProvingSystem::Spartan2 => "spartan2",
             ProvingSystem::RookieNumbers => "rookie-numbers",
             ProvingSystem::StarkV => "stark-v",
+            ProvingSystem::Zolt => "zolt",
         }
     }
 }

--- a/zolt-bench/Cargo.toml
+++ b/zolt-bench/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "zolt-bench"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { workspace = true }
+criterion = { workspace = true }
+utils = { workspace = true }
+
+[[bench]]
+name = "sha256"
+harness = false
+
+[[bin]]
+name = "sha256_mem_zolt"
+path = "src/bin/sha256_mem.rs"

--- a/zolt-bench/benches/sha256.rs
+++ b/zolt-bench/benches/sha256.rs
@@ -1,0 +1,20 @@
+use utils::harness::{BenchTarget, ProvingSystem};
+use zolt_bench::{
+    prepare_sha256, preprocessing_size, proof_size, prove_sha256, verify_sha256,
+    zolt_bench_properties, PreparedZoltSha256, ZoltProofResult, ZoltSharedState,
+};
+
+utils::define_benchmark_harness!(
+    BenchTarget::Sha256,
+    ProvingSystem::Zolt,
+    None,
+    "sha256_mem_zolt",
+    zolt_bench_properties(),
+    { ZoltSharedState::new() },
+    |size, shared: &ZoltSharedState| prepare_sha256(size, *shared),
+    |_: &PreparedZoltSha256, _: &&ZoltSharedState| 0usize,
+    |prepared: &PreparedZoltSha256, shared: &&ZoltSharedState| prove_sha256(prepared, shared),
+    |prepared: &PreparedZoltSha256, proof: &ZoltProofResult, shared: &&ZoltSharedState| verify_sha256(prepared, proof, shared),
+    |prepared: &PreparedZoltSha256, shared: &&ZoltSharedState| preprocessing_size(prepared, shared),
+    |proof: &ZoltProofResult, shared: &&ZoltSharedState| proof_size(proof, shared)
+);

--- a/zolt-bench/build.rs
+++ b/zolt-bench/build.rs
@@ -1,0 +1,53 @@
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    let zolt_dir = PathBuf::from(
+        env::var("ZOLT_DIR").unwrap_or_else(|_| {
+            // Default: sibling directory to csp-benchmarks
+            let manifest = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+            manifest
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .join("zolt")
+                .to_string_lossy()
+                .into_owned()
+        }),
+    );
+
+    // Build zolt C-API static library
+    let status = Command::new("zig")
+        .args(["build", "-Doptimize=ReleaseFast"])
+        .current_dir(&zolt_dir)
+        .status()
+        .expect("Failed to run `zig build`. Is Zig installed?");
+    assert!(status.success(), "zig build failed");
+
+    let lib_dir = zolt_dir.join("zig-out").join("lib");
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    println!("cargo:rustc-link-lib=static=zolt_capi");
+
+    // macOS system frameworks required by Zig's Metal backend + ObjC runtime
+    if cfg!(target_os = "macos") {
+        println!("cargo:rustc-link-lib=framework=Metal");
+        println!("cargo:rustc-link-lib=framework=CoreGraphics");
+        println!("cargo:rustc-link-lib=framework=Foundation");
+        println!("cargo:rustc-link-lib=framework=QuartzCore");
+        println!("cargo:rustc-link-lib=objc");
+    }
+
+    // Emit examples directory path for ELF lookup at runtime
+    let examples_dir = zolt_dir.join("examples");
+    println!(
+        "cargo:rustc-env=ZOLT_EXAMPLES_DIR={}",
+        examples_dir.display()
+    );
+
+    // Rerun if zolt sources change
+    println!("cargo:rerun-if-changed={}/src", zolt_dir.display());
+    println!("cargo:rerun-if-changed={}/build.zig", zolt_dir.display());
+    println!("cargo:rerun-if-env-changed=ZOLT_DIR");
+}

--- a/zolt-bench/src/bin/sha256_mem.rs
+++ b/zolt-bench/src/bin/sha256_mem.rs
@@ -1,0 +1,15 @@
+use clap::Parser;
+use zolt_bench::{prepare_sha256, prove_sha256, ZoltSharedState};
+
+#[derive(Parser)]
+struct Args {
+    #[arg(long = "input-size")]
+    input_size: usize,
+}
+
+fn main() {
+    let args = Args::parse();
+    let shared = ZoltSharedState::new();
+    let prepared = prepare_sha256(args.input_size, shared);
+    let _proof = prove_sha256(&prepared, &shared);
+}

--- a/zolt-bench/src/ffi.rs
+++ b/zolt-bench/src/ffi.rs
@@ -1,0 +1,20 @@
+use std::ffi::c_void;
+
+#[allow(dead_code)]
+unsafe extern "C" {
+    pub fn zolt_thread_pool_create() -> *mut c_void;
+    pub fn zolt_thread_pool_destroy(handle: *mut c_void);
+
+    pub fn zolt_load_elf(
+        tp_handle: *mut c_void,
+        path_ptr: *const u8,
+        path_len: usize,
+    ) -> *mut c_void;
+    pub fn zolt_loaded_elf_size(handle: *mut c_void) -> usize;
+    pub fn zolt_loaded_elf_destroy(handle: *mut c_void);
+
+    pub fn zolt_prove(elf_handle: *mut c_void) -> *mut c_void;
+
+    pub fn zolt_proof_result_size(handle: *mut c_void) -> usize;
+    pub fn zolt_proof_result_destroy(handle: *mut c_void);
+}

--- a/zolt-bench/src/lib.rs
+++ b/zolt-bench/src/lib.rs
@@ -1,0 +1,136 @@
+mod ffi;
+
+use std::ffi::c_void;
+use std::path::PathBuf;
+use utils::harness::{AuditStatus, BenchProperties};
+
+// ---------------------------------------------------------------------------
+// Safe wrappers around the Zig C-API opaque handles
+// ---------------------------------------------------------------------------
+
+/// Shared state across all benchmark iterations. Holds the Zig thread pool.
+/// Implements `Copy` (required by the harness) — it's just a raw pointer.
+/// The thread pool is intentionally leaked (lives for the entire process).
+#[derive(Clone, Copy)]
+pub struct ZoltSharedState {
+    tp_handle: *mut c_void,
+}
+
+// SAFETY: The thread pool is accessed only through the C API which
+// internally synchronises via its work-stealing queues.
+unsafe impl Send for ZoltSharedState {}
+unsafe impl Sync for ZoltSharedState {}
+
+impl ZoltSharedState {
+    pub fn new() -> Self {
+        let tp_handle = unsafe { ffi::zolt_thread_pool_create() };
+        assert!(!tp_handle.is_null(), "zolt: failed to create thread pool");
+        Self { tp_handle }
+    }
+}
+
+/// Prepared context for a single SHA-256 input size.
+/// Holds the loaded ELF and a reference to the shared thread pool.
+pub struct PreparedZoltSha256 {
+    elf_handle: *mut c_void,
+    elf_byte_size: usize,
+}
+
+impl Drop for PreparedZoltSha256 {
+    fn drop(&mut self) {
+        if !self.elf_handle.is_null() {
+            unsafe { ffi::zolt_loaded_elf_destroy(self.elf_handle) };
+        }
+    }
+}
+
+/// Proof artifact returned by `prove_sha256`.
+pub struct ZoltProofResult {
+    handle: *mut c_void,
+}
+
+impl Drop for ZoltProofResult {
+    fn drop(&mut self) {
+        if !self.handle.is_null() {
+            unsafe { ffi::zolt_proof_result_destroy(self.handle) };
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark harness functions (matching Jolt's pattern exactly)
+// ---------------------------------------------------------------------------
+
+pub fn zolt_bench_properties() -> BenchProperties {
+    BenchProperties::new(
+        "Zolt",
+        "Bn254",
+        "Twist & Shout",
+        Some("Dory"),
+        "Jolt",
+        false, // is_zk
+        true,  // is_zkvm
+        128,   // security_bits
+        false, // is_pq
+        true,  // is_maintained
+        AuditStatus::NotAudited,
+        Some("RISC-V RV64IMC"),
+    )
+}
+
+/// Maps input_size (bytes) to the corresponding pre-built ELF path.
+fn elf_path_for_size(input_size: usize) -> PathBuf {
+    let examples_dir = PathBuf::from(env!("ZOLT_EXAMPLES_DIR"));
+    if input_size == 256 {
+        examples_dir.join("sha256.elf")
+    } else {
+        examples_dir.join(format!("sha256_{input_size}.elf"))
+    }
+}
+
+/// Prepare: load ELF + init prover context. NOT timed by Criterion.
+pub fn prepare_sha256(input_size: usize, shared: ZoltSharedState) -> PreparedZoltSha256 {
+    let path = elf_path_for_size(input_size);
+    let path_bytes = path.to_str().expect("non-UTF8 path").as_bytes();
+
+    let elf_handle = unsafe {
+        ffi::zolt_load_elf(shared.tp_handle, path_bytes.as_ptr(), path_bytes.len())
+    };
+    assert!(
+        !elf_handle.is_null(),
+        "zolt: failed to load ELF at {}",
+        path.display()
+    );
+
+    let elf_byte_size = unsafe { ffi::zolt_loaded_elf_size(elf_handle) };
+
+    PreparedZoltSha256 {
+        elf_handle,
+        elf_byte_size,
+    }
+}
+
+/// Prove: full pipeline (trace + preprocess + prove). TIMED by Criterion.
+pub fn prove_sha256(prepared: &PreparedZoltSha256, _shared: &ZoltSharedState) -> ZoltProofResult {
+    let handle = unsafe { ffi::zolt_prove(prepared.elf_handle) };
+    assert!(!handle.is_null(), "zolt: proving failed");
+    ZoltProofResult { handle }
+}
+
+/// Verify: not yet implemented — no-op.
+pub fn verify_sha256(
+    _prepared: &PreparedZoltSha256,
+    _proof: &ZoltProofResult,
+    _shared: &ZoltSharedState,
+) {
+}
+
+/// Returns ELF bytecode size as a proxy for preprocessing size.
+pub fn preprocessing_size(prepared: &PreparedZoltSha256, _shared: &ZoltSharedState) -> usize {
+    prepared.elf_byte_size
+}
+
+/// Returns serialized proof size in bytes.
+pub fn proof_size(proof: &ZoltProofResult, _shared: &ZoltSharedState) -> usize {
+    unsafe { ffi::zolt_proof_result_size(proof.handle) }
+}


### PR DESCRIPTION
## Summary
- Add `zolt-bench` crate with SHA-256 benchmark harness for Zolt (Zig zkVM) using C-API FFI
- Add `Zolt` variant to `ProvingSystem` enum in shared harness
- Add `zolt-bench` to workspace members

## Test plan
- [ ] `cargo bench --bench sha256 -p zolt-bench -- --test` passes with `ZOLT_DIR` pointing to a zolt checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)