### PR TITLE
Exclude Miden ECDSA benchmark from the default benchmark suite and results

### DIFF
--- a/miden/Cargo.toml
+++ b/miden/Cargo.toml
@@ -3,6 +3,9 @@ name = "miden"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+miden-ecdsa-bench = []
+
 [dependencies]
 ere-miden = { git = "https://github.com/eth-act/ere", rev = "6573843" }
 bincode = { workspace = true }
@@ -21,6 +24,7 @@ harness = false
 [[bench]]
 name = "ecdsa"
 harness = false
+required-features = ["miden-ecdsa-bench"]
 
 [[bin]]
 name = "sha256_mem_miden"
@@ -29,3 +33,4 @@ path = "src/bin/sha256_mem.rs"
 [[bin]]
 name = "ecdsa_mem_miden"
 path = "src/bin/ecdsa_mem.rs"
+required-features = ["miden-ecdsa-bench"]

--- a/results/collected_benchmarks_23330555957.json
+++ b/results/collected_benchmarks_23330555957.json
@@ -1482,18 +1482,6 @@
     },
     {
       "system": "miden",
-      "target": "ecdsa",
-      "input_size": 32,
-      "proof_duration": 335068896,
-      "verify_duration": 1383085,
-      "cycles": 996,
-      "proof_size": 126961,
-      "preprocessing_size": 3858,
-      "num_constraints": 0,
-      "peak_memory": 56927846
-    },
-    {
-      "system": "miden",
       "target": "sha256",
       "input_size": 1024,
       "proof_duration": 31672303121,


### PR DESCRIPTION
In the Miden guest, the program calls a deferred ECDSA precompile wrapper, not an in-VM ECDSA implementation. The actual signature check is done by the host-side precompile handler during execution and then re-run by the verifier. Therefore, it's not fair to compare Miden with the other systems in this repo.