### PR TITLE
Bump ProveKit to cc391c8c and report .pkp size as preprocessing_size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,11 +2490,11 @@ dependencies = [
 [[package]]
 name = "bn254-multiplier"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334#de6da630b498be13fa7162cb1e69df3f76593334"
+source = "git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd#cc391c8cc72766cc47f8243402e7f51e16c6d7cd"
 dependencies = [
- "bn254-multiplier-codegen 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
- "fp-rounding 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
- "hla 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
+ "bn254-multiplier-codegen 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
+ "fp-rounding 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
+ "hla 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
  "seq-macro",
 ]
 
@@ -2509,9 +2509,9 @@ dependencies = [
 [[package]]
 name = "bn254-multiplier-codegen"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334#de6da630b498be13fa7162cb1e69df3f76593334"
+source = "git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd#cc391c8cc72766cc47f8243402e7f51e16c6d7cd"
 dependencies = [
- "hla 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
+ "hla 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
 ]
 
 [[package]]
@@ -4953,7 +4953,7 @@ source = "git+https://github.com/worldfnd/ProveKit?rev=b910fe8da2b909bb84f0c48a5
 [[package]]
 name = "fp-rounding"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334#de6da630b498be13fa7162cb1e69df3f76593334"
+source = "git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd#cc391c8cc72766cc47f8243402e7f51e16c6d7cd"
 
 [[package]]
 name = "fs-err"
@@ -5721,7 +5721,7 @@ dependencies = [
 [[package]]
 name = "hla"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334#de6da630b498be13fa7162cb1e69df3f76593334"
+source = "git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd#cc391c8cc72766cc47f8243402e7f51e16c6d7cd"
 dependencies = [
  "paste",
 ]
@@ -7926,11 +7926,11 @@ dependencies = [
 [[package]]
 name = "ntt"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334#de6da630b498be13fa7162cb1e69df3f76593334"
+source = "git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd#cc391c8cc72766cc47f8243402e7f51e16c6d7cd"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.5.0",
- "bn254-multiplier 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
+ "bn254-multiplier 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
  "rayon",
 ]
 
@@ -10663,7 +10663,7 @@ dependencies = [
 [[package]]
 name = "poseidon2"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334#de6da630b498be13fa7162cb1e69df3f76593334"
+source = "git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd#cc391c8cc72766cc47f8243402e7f51e16c6d7cd"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.5.0",
@@ -10941,10 +10941,10 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "criterion",
- "provekit-common 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
- "provekit-prover 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
- "provekit-r1cs-compiler 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
- "provekit-verifier 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
+ "provekit-common 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
+ "provekit-prover 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
+ "provekit-r1cs-compiler 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
+ "provekit-verifier 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
  "rand 0.8.5",
  "utils 0.1.0",
 ]
@@ -10991,7 +10991,7 @@ dependencies = [
 [[package]]
 name = "provekit-common"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334#de6da630b498be13fa7162cb1e69df3f76593334"
+source = "git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd#cc391c8cc72766cc47f8243402e7f51e16c6d7cd"
 dependencies = [
  "acir",
  "anyhow",
@@ -11008,8 +11008,8 @@ dependencies = [
  "mavros-artifacts",
  "mavros-vm",
  "noirc_abi",
- "ntt 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
- "poseidon2 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
+ "ntt 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
+ "poseidon2 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
  "postcard",
  "rayon",
  "ruint",
@@ -11017,7 +11017,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sha3",
- "skyscraper 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
+ "skyscraper 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
  "spongefish",
  "spongefish-pow",
  "tracing",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "provekit-prover"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334#de6da630b498be13fa7162cb1e69df3f76593334"
+source = "git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd#cc391c8cc72766cc47f8243402e7f51e16c6d7cd"
 dependencies = [
  "acir",
  "anyhow",
@@ -11115,7 +11115,7 @@ dependencies = [
  "noirc_abi",
  "num-bigint 0.4.6",
  "postcard",
- "provekit-common 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
+ "provekit-common 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
  "tracing",
  "whir",
 ]
@@ -11145,7 +11145,7 @@ dependencies = [
 [[package]]
 name = "provekit-r1cs-compiler"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334#de6da630b498be13fa7162cb1e69df3f76593334"
+source = "git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd#cc391c8cc72766cc47f8243402e7f51e16c6d7cd"
 dependencies = [
  "acir",
  "anyhow",
@@ -11155,9 +11155,9 @@ dependencies = [
  "mavros-artifacts",
  "noirc_abi",
  "noirc_artifacts",
- "poseidon2 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
+ "poseidon2 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
  "postcard",
- "provekit-common 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
+ "provekit-common 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
  "serde",
  "serde_json",
  "tracing",
@@ -11183,11 +11183,11 @@ dependencies = [
 [[package]]
 name = "provekit-verifier"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334#de6da630b498be13fa7162cb1e69df3f76593334"
+source = "git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd#cc391c8cc72766cc47f8243402e7f51e16c6d7cd"
 dependencies = [
  "anyhow",
  "ark-std 0.5.0",
- "provekit-common 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
+ "provekit-common 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
  "rayon",
  "tracing",
  "whir",
@@ -13064,12 +13064,12 @@ dependencies = [
 [[package]]
 name = "skyscraper"
 version = "0.1.0"
-source = "git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334#de6da630b498be13fa7162cb1e69df3f76593334"
+source = "git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd#cc391c8cc72766cc47f8243402e7f51e16c6d7cd"
 dependencies = [
  "ark-bn254",
  "ark-ff 0.5.0",
- "bn254-multiplier 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
- "fp-rounding 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=de6da630b498be13fa7162cb1e69df3f76593334)",
+ "bn254-multiplier 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
+ "fp-rounding 0.1.0 (git+https://github.com/worldfnd/ProveKit?rev=cc391c8cc72766cc47f8243402e7f51e16c6d7cd)",
  "rayon",
  "seq-macro",
  "zerocopy",

--- a/provekit/Cargo.toml
+++ b/provekit/Cargo.toml
@@ -8,10 +8,10 @@ rand = { workspace = true }
 utils = { workspace = true }
 criterion = { workspace = true }
 clap = { workspace = true }
-provekit-common = { git = "https://github.com/worldfnd/ProveKit", rev = "de6da630b498be13fa7162cb1e69df3f76593334"}
-provekit-r1cs-compiler = { git = "https://github.com/worldfnd/ProveKit", rev = "de6da630b498be13fa7162cb1e69df3f76593334"}
-provekit-prover = { git = "https://github.com/worldfnd/ProveKit", rev = "de6da630b498be13fa7162cb1e69df3f76593334"}
-provekit-verifier = { git = "https://github.com/worldfnd/ProveKit", rev = "de6da630b498be13fa7162cb1e69df3f76593334"}
+provekit-common = { git = "https://github.com/worldfnd/ProveKit", rev = "cc391c8cc72766cc47f8243402e7f51e16c6d7cd"}
+provekit-r1cs-compiler = { git = "https://github.com/worldfnd/ProveKit", rev = "cc391c8cc72766cc47f8243402e7f51e16c6d7cd"}
+provekit-prover = { git = "https://github.com/worldfnd/ProveKit", rev = "cc391c8cc72766cc47f8243402e7f51e16c6d7cd"}
+provekit-verifier = { git = "https://github.com/worldfnd/ProveKit", rev = "cc391c8cc72766cc47f8243402e7f51e16c6d7cd"}
 
 [[bin]]
 name = "sha256_mem_provekit"

--- a/provekit/benches/ecdsa.rs
+++ b/provekit/benches/ecdsa.rs
@@ -13,6 +13,6 @@ utils::define_benchmark_harness!(
     |(proof_scheme, _, _), proof| {
         verify(proof, proof_scheme).unwrap();
     },
-    |(_, _, circuit_path)| { preprocessing_size(circuit_path) },
+    |(proof_scheme, _, _)| { preprocessing_size(proof_scheme) },
     |proof| { proof.whir_r1cs_proof.narg_string.len() + proof.whir_r1cs_proof.hints.len() }
 );

--- a/provekit/benches/keccak.rs
+++ b/provekit/benches/keccak.rs
@@ -13,6 +13,6 @@ utils::define_benchmark_harness!(
     |(proof_scheme, _, _), proof| {
         verify(proof, proof_scheme).unwrap();
     },
-    |(_, _, circuit_path)| { preprocessing_size(circuit_path) },
+    |(proof_scheme, _, _)| { preprocessing_size(proof_scheme) },
     |proof| { proof.whir_r1cs_proof.narg_string.len() + proof.whir_r1cs_proof.hints.len() }
 );

--- a/provekit/benches/poseidon.rs
+++ b/provekit/benches/poseidon.rs
@@ -13,6 +13,6 @@ utils::define_benchmark_harness!(
     |(proof_scheme, _, _), proof| {
         verify(proof, proof_scheme).unwrap();
     },
-    |(_, _, circuit_path)| { preprocessing_size(circuit_path) },
+    |(proof_scheme, _, _)| { preprocessing_size(proof_scheme) },
     |proof| { proof.whir_r1cs_proof.narg_string.len() + proof.whir_r1cs_proof.hints.len() }
 );

--- a/provekit/benches/poseidon2.rs
+++ b/provekit/benches/poseidon2.rs
@@ -13,6 +13,6 @@ utils::define_benchmark_harness!(
     |(proof_scheme, _, _), proof| {
         verify(proof, proof_scheme).unwrap();
     },
-    |(_, _, circuit_path)| { preprocessing_size(circuit_path) },
+    |(proof_scheme, _, _)| { preprocessing_size(proof_scheme) },
     |proof| { proof.whir_r1cs_proof.narg_string.len() + proof.whir_r1cs_proof.hints.len() }
 );

--- a/provekit/benches/sha256.rs
+++ b/provekit/benches/sha256.rs
@@ -13,6 +13,6 @@ utils::define_benchmark_harness!(
     |(proof_scheme, _, _), proof| {
         verify(proof, proof_scheme).unwrap();
     },
-    |(_, _, circuit_path)| { preprocessing_size(circuit_path) },
+    |(proof_scheme, _, _)| { preprocessing_size(proof_scheme) },
     |proof| { proof.whir_r1cs_proof.narg_string.len() + proof.whir_r1cs_proof.hints.len() }
 );

--- a/provekit/src/lib.rs
+++ b/provekit/src/lib.rs
@@ -1,4 +1,4 @@
-use provekit_common::{HashConfig, NoirProof, NoirProofScheme, Prover, Verifier};
+use provekit_common::{HashConfig, NoirProof, NoirProofScheme, Prover, Verifier, file::serialize};
 use provekit_prover::Prove;
 use provekit_r1cs_compiler::NoirCompiler;
 use provekit_verifier::Verify;
@@ -163,8 +163,9 @@ pub fn verify(proof: &NoirProof, proof_scheme: &NoirProofScheme) -> Result<(), &
     verifier.verify(proof).map_err(|_| "Proof is not valid")
 }
 
-pub fn preprocessing_size(circuit_path: &Path) -> usize {
-    std::fs::metadata(circuit_path)
-        .map(|m| m.len())
-        .unwrap_or(0) as usize
+pub fn preprocessing_size(proof_scheme: &NoirProofScheme) -> usize {
+    let prover = Prover::from_noir_proof_scheme(proof_scheme.clone());
+    serialize(&prover)
+        .expect("serialize Prover to .pkp bytes")
+        .len()
 }


### PR DESCRIPTION
1. **Bump ProveKit to `cc391c8c`— toolchain bump required by upstream's new portable-simd usage. Adapts code for the forced API drift (`NoirCompiler::from_file`, `prove_with_toml`, `r1cs()` accessor, `WhirR1CSProof.narg_string + hints`).
2. **Report `.pkp` byte size as `preprocessing_size`** — uses `provekit_common::file::serialize(&prover)`. Counts the full prover bundle (program, R1CS, witness generator, ABI, hash config), matching the methodology used for the Groth16 flavour in #284.